### PR TITLE
fix ellipsoid indicator

### DIFF
--- a/holopy/scattering/scatterer/ellipsoid.py
+++ b/holopy/scattering/scatterer/ellipsoid.py
@@ -69,6 +69,6 @@ class Ellipsoid(CenteredScatterer):
     # TODO: does not handle rotations
     @property
     def indicators(self):
-        return Indicators(lambda point: ((point / self.r) ** 2).sum() < 1,
+        return Indicators(lambda point: ((point / self.r) ** 2).sum(-1) < 1,
                           [[-self.r[0], self.r[0]], [-self.r[1], self.r[1]],
                             [-self.r[2], self.r[2]]])

--- a/holopy/scattering/tests/test_scatterer.py
+++ b/holopy/scattering/tests/test_scatterer.py
@@ -176,3 +176,16 @@ def test_sphere_nocenter():
 def test_calc_holo_nopolarization():
     sphere = Sphere(n = 1.59, r = .5, center = (5, 5, 5))
     assert_warns(UserWarning, Optics, wavelen = .660, index = 1.33)
+
+def test_ellipsoid():
+    test = Ellipsoid(n = 1.585, r = [.4,0.4,1.5], center = [10,10,20])
+    assert_equal(test.voxelate(.4), np.array(
+        [[[0., 0., 0., 0., 0., 0., 0., 0.],
+          [0., 0., 0., 0., 0., 0., 0., 0.],
+          [0., 0., 0., 0., 0., 0., 0., 0.]],
+         [[0., 0., 0., 0., 0., 0., 0., 0.],
+          [0., 1.585, 1.585, 1.585, 1.585, 1.585, 1.585, 1.585],
+          [0., 0., 0., 0., 0., 0., 0., 0.]],
+         [[0., 0., 0., 0., 0., 0., 0., 0.],
+          [0., 0., 0., 0., 0., 0., 0., 0.],
+          [0., 0., 0., 0., 0., 0., 0., 0.]]]))


### PR DESCRIPTION
The indicator function for the ellipsoid scatterer had a sum specified incorretly, so it was failing to think that the ellipsoid contained points when given a 2 or 3d array of points (which happens when you try to voxelate scatterers). 

Fixes #8
