### PR TITLE
fix models so the theory roundtrips to yaml properly

### DIFF
--- a/holopy/fitting/model.py
+++ b/holopy/fitting/model.py
@@ -240,6 +240,13 @@ class Model(HoloPyObject):
         if not isinstance(scatterer, Parametrization):
             scatterer = ParameterizedObject(scatterer)
         self.scatterer = scatterer
+
+        if isinstance(theory, basestring):
+            import holopy.scattering.theory as theory_module
+            kind, func = theory.split('.')
+            theory = getattr(getattr(theory_module, kind), func)
+
+
         self.theory = theory
         self.use_random_fraction = use_random_fraction
 
@@ -273,3 +280,15 @@ class Model(HoloPyObject):
         return self.theory(self.scatterer.guess, schema, alpha)
 
     # TODO: Allow a layer on top of theory to do things like moving sphere
+
+    @property
+    def _dict(self):
+        d = super(Model, self)._dict
+        theory = d['theory']
+        # if the theory is something like Mie.calc_holo, rather than
+        # Mie().calc_holo, we need to represent it differently
+        if isinstance(theory.im_class, type):
+            theory_class = theory.im_self.__name__
+            theory_func = theory.im_func.__name__
+            d['theory'] = '.'.join((theory_class, theory_func))
+        return d

--- a/holopy/fitting/tests/test_model.py
+++ b/holopy/fitting/tests/test_model.py
@@ -23,10 +23,11 @@ import numpy as np
 
 from nose.plugins.attrib import attr
 from numpy.testing import assert_equal
-from ...scattering.theory import Mie
-from ...scattering.scatterer import Sphere, Spheres, Scatterer
-from .. import fit, par, Model, ComplexParameter, Parametrization
-from ...core.tests.common import assert_obj_close, get_example_data
+from holopy.scattering.theory import Mie
+from holopy.scattering.scatterer import Sphere, Spheres, Scatterer
+from holopy.fitting import fit, par, Model, ComplexParameter, Parametrization
+from holopy.core.tests.common import assert_obj_close, get_example_data
+from holopy.core.tests.common import assert_read_matches_write
 
 @attr('fast')
 def test_naming():
@@ -36,9 +37,9 @@ def test_naming():
         n**2+m
         return fake_sph
     parm = Parametrization(makeScatterer, [par(limit=4),par(2, [1,5])])
-    
+
     assert_equal(parm._fixed_params,{None: 4})
-    
+
 @attr('fast')
 def test_Get_Alpha():
 
@@ -50,12 +51,12 @@ def test_Get_Alpha():
     sc = Spheres([Sphere(n = 1.58, r = par(0.5e-6), center = np.array([10., 10., 20.])),
               Sphere(n = 1.58, r = par(0.5e-6), center = np.array([9., 11., 21.]))])
     model2 = Model(sc, Mie.calc_holo)
-              
+
     assert_equal(model.get_alpha(model.parameters).guess, 0.7)
     assert_equal(model.get_alpha(model.parameters).name, 'alpha')
     assert_equal(model2.get_alpha(model2.parameters), 1.0)
-    
-    
+
+
 @attr('fast')
 def test_Tying():
 
@@ -64,12 +65,12 @@ def test_Tying():
     sc = Spheres([Sphere(n = n1, r = par(0.5e-6), center = np.array([10., 10., 20.])),
               Sphere(n = n1, r = par(0.5e-6), center = np.array([9., 11., 21.]))])
     model = Model(sc, Mie.calc_holo, alpha = par(.7,[.6,1]))
-              
+
     assert_equal(model.parameters[0].guess, 1.59)
     assert_equal(model.parameters[1].guess, 5e-7)
     assert_equal(len(model.parameters),4)
-    
-    
+
+
 @attr('fast')
 def test_ComplexPar():
 
@@ -77,10 +78,10 @@ def test_ComplexPar():
     def makeScatterer(n):
         n**2
         return fake_sph
-        
+
     parm = Parametrization(makeScatterer, [ComplexParameter(real = par(1.58),imag = par(.001), name='n')])
     model = Model(parm, Mie.calc_holo, alpha = par(.7,[.6,1]))
-    
+
     assert_equal(model.parameters[0].name,'n.real')
     assert_equal(model.parameters[1].name,'n.imag')
 
@@ -110,3 +111,9 @@ def test_pullingoutguess():
     assert_equal(s.r, model.scatterer.guess.r)
     assert_equal(s.center, model.scatterer.guess.center)
 
+def test_io():
+    model = Model(Sphere(par(1)), Mie.calc_holo)
+    assert_read_matches_write(model)
+
+    model = Model(Sphere(par(1)), Mie(False).calc_holo)
+    assert_read_matches_write(model)


### PR DESCRIPTION
This PR makes it so you can actually write Models to yaml and read them back. Previously there were issues with the way something like Mie.calc_holo got written. Now we just write that as a string "Mie.calc_holo", and the constructor for models understands string theory specifications and does the correct thing.