### PR TITLE
Fix the bug with holopy crashing because it can't find undecorated

### DIFF
--- a/holopy/core/io/io.py
+++ b/holopy/core/io/io.py
@@ -151,8 +151,11 @@ def average_images(images, spacing=None, optics=None, image_glob='*.tif'):
         Image which is an average of images
     """
 
-    if os.path.isdir(images):
-        images = glob.glob(os.path.join(images, image_glob))
+    try:
+        if os.path.isdir(images):
+            images = glob.glob(os.path.join(images, image_glob))
+    except TypeError:
+        pass
 
     if len(images) < 1:
         raise Error("No images found")

--- a/holopy/scattering/binding_method.py
+++ b/holopy/scattering/binding_method.py
@@ -18,7 +18,7 @@
 """
 Allow mixed class/instance methods that operate either on a default object of a
 class when called as a classmethod or on a supplied instance when called as an
-instance method.  
+instance method.
 
 So if you have a class like this
 ---
@@ -48,11 +48,11 @@ from __future__ import division
 
 import inspect
 import types
-try:
-    from decorator import decorator
-except ImportError:
-    from .third_party.decorator import decorator # pragma: no cover
-    
+#try:
+    #from decorator import decorator
+#except ImportError:
+from .third_party.decorator import decorator # pragma: no cover
+
 
 def finish_binding(obj):
     """
@@ -76,8 +76,8 @@ def binding(f, *args, **kw):
     r._bindme = True
     return r
 
-        
+
 def _binding(f, *args, **kw):
     if isinstance(args[0], type):
         args = (args[0](),)+args[1:]
-    return f(*args, **kw)   
+    return f(*args, **kw)


### PR DESCRIPTION
An update to the decorator library has broken holopy. However, holopy ships with an old version that works, but prefers to use the system installed version if it is available. This patch switches holopy to always use its bundled version which should fix that problem.

As a bonus (because it was hanging out in my tree), it also fixes a random type error that could occur when using the average_images function.