### PR TITLE
Convert scattering tests to new interface

### DIFF
--- a/holopy/core/marray.py
+++ b/holopy/core/marray.py
@@ -183,12 +183,6 @@ class Schema(HoloPyObject):
     def positions(self, val):
         self._positions = val
 
-    # TODO: put this somewhere sensible, make it handle phi as well
-    def positions_theta_phi(self):
-        if isinstance(self.positions, Angles):
-            return self.positions.positions_theta_phi()
-        else:
-            raise UnspecifiedPosition()
 
     # TODO: need equivalents for set_metadata or to rewrite other code so it
     # doesn't need it.

--- a/holopy/core/metadata.py
+++ b/holopy/core/metadata.py
@@ -222,7 +222,9 @@ class Angles(PositionSpecification):
         self.phi = phi
         self.shape = len(self.theta), len(self.phi)
 
-    def positions_theta_phi(self):
+    def theta_phi(self, center=None):
+        # ignore the center coordinate, but we accept it for compatability with
+        # other positions objects that need a center to determine angles
         pos = np.zeros((self.shape[0]*self.shape[1], 2))
         for i, theta in enumerate(self.theta):
             for j, phi in enumerate(self.phi):

--- a/holopy/core/metadata.py
+++ b/holopy/core/metadata.py
@@ -178,6 +178,9 @@ class Positions(np.ndarray, HoloPyObject):
 
         return np.vstack((r, theta, phi)).T
 
+    def theta_phi(self, origin):
+        return self.r_theta_phi(origin)[:, 1:]
+
     def kr_theta_phi(self, origin, wavevec):
         pos = self.r_theta_phi(origin)
         pos[:,0] *= wavevec
@@ -222,7 +225,7 @@ class Angles(PositionSpecification):
         self.phi = phi
         self.shape = len(self.theta), len(self.phi)
 
-    def theta_phi(self, center=None):
+    def theta_phi(self, origin=None):
         # ignore the center coordinate, but we accept it for compatability with
         # other positions objects that need a center to determine angles
         pos = np.zeros((self.shape[0]*self.shape[1], 2))

--- a/holopy/scattering/calculations.py
+++ b/holopy/scattering/calculations.py
@@ -28,7 +28,7 @@ from holopy.core.helpers import dict_without
 from holopy.core.helpers import is_none
 from holopy.scattering.scatterer import Sphere, Spheres
 from holopy.scattering.theory import Mie, Multisphere, dda
-from holopy.scattering.errors import AutoTheoryFailed
+from holopy.scattering.errors import AutoTheoryFailed, NoCenter
 
 import numpy as np
 

--- a/holopy/scattering/tests/test_scatterer.py
+++ b/holopy/scattering/tests/test_scatterer.py
@@ -39,7 +39,7 @@ from ..scatterer.scatterer import find_bounds
 
 from ..errors import ScattererDefinitionError, NoCenter, NoPolarization
 from .common import assert_allclose
-from ..theory import Mie
+from holopy.scattering.calculations import calc_holo
 
 @attr('fast')
 def test_Sphere_construction():
@@ -170,7 +170,7 @@ def test_find_bounds():
 def test_sphere_nocenter():
     sphere = Sphere(n = 1.59, r = .5)
     schema = ImageSchema(spacing=.1, shape=1, optics=Optics(wavelen = .660, polarization = [1, 0],index = 1.33))
-    assert_raises(NoCenter, Mie.calc_holo, sphere, schema)
+    assert_raises(NoCenter, calc_holo, sphere, 1.33, .66, schema)
 
 def test_ellipsoid():
     test = Ellipsoid(n = 1.585, r = [.4,0.4,1.5], center = [10,10,20])

--- a/holopy/scattering/theory/mie.py
+++ b/holopy/scattering/theory/mie.py
@@ -80,7 +80,7 @@ class Mie(FortranTheory):
 
             # TODO: actually use (rather than ignore) the phi
             scat_matrs = [mieangfuncs.asm_mie_far(scat_coeffs, theta) for
-                          theta, phi in schema.positions_theta_phi(scatterer.center)]
+                          theta, phi in schema.positions.theta_phi(scatterer.center)]
             return np.array(scat_matrs)
         else:
             raise TheoryNotCompatibleError(self, scatterer)

--- a/holopy/scattering/theory/multisphere.py
+++ b/holopy/scattering/theory/multisphere.py
@@ -233,10 +233,10 @@ class Multisphere(FortranTheory):
         cext = 4. * np.pi / optics.wavevec**2 * np.dot(pol, ascat_sph).real
         return cext
 
-    def _calc_scat_matrix(self, scatterer, schema):
-        amn, lmax = self._scsmfo_setup(scatterer, schema.optics)
+    def _calc_scat_matrix(self, scatterer, schema, optics):
+        amn, lmax = self._scsmfo_setup(scatterer, optics)
         scat_matrs = [_asm_far(theta, phi, amn, lmax) for
-                      theta, phi in schema.positions_theta_phi()]
+                      theta, phi in schema.positions.theta_phi()]
         return np.array(scat_matrs)
 
     def _calc_cscat(self, scatterer, optics, amn = None, lmax = None):


### PR DESCRIPTION
This PR converts the rest of the scattering tests to use the new interface. It also cleans up a few things in marray and metadata