### PR TITLE
remove direct pandas dependency since we don't use it anymore

### DIFF
--- a/holopy/inference/noise_model.py
+++ b/holopy/inference/noise_model.py
@@ -22,7 +22,6 @@ from holopy.core.holopy_object import HoloPyObject
 from holopy.scattering.errors import MultisphereFailure, InvalidScatterer
 
 import numpy as np
-import pandas as pd
 from copy import copy
 from holopy.scattering.calculations import calc_field, calc_holo
 

--- a/holopy/scattering/tests/test_dda.py
+++ b/holopy/scattering/tests/test_dda.py
@@ -54,7 +54,7 @@ def teardown_optics():
 
 def calc_holo(schema, scatterer, medium_index=None, illum_wavelen=None,**kwargs):
     try:
-        return calc_holo_external(schema, scatterer, index, wavelen, **kwargs)
+        return calc_holo_external(schema, scatterer, medium_index, illum_wavelen, **kwargs)
     except DependencyMissing:
         raise SkipTest()
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
           name='HoloPy',
           version=__version__,
           description='Holography in Python',
-          requires=['numpy', 'scipy', 'PyYAML', 'pillow','pandas','h5py','emcee','matplotlib','xarray','h5netcdf'],
+          requires=['numpy', 'scipy', 'PyYAML', 'pillow','h5py','emcee','matplotlib','xarray','h5netcdf'],
           author='Manoharan Lab, Harvard University',
           author_email='vnm@seas.harvard.edu',
           url='http://manoharan.seas.harvard.edu/holopy',


### PR DESCRIPTION
It's easy to revert if we end up needing pandas again for pairplots, etc.