### PR TITLE
remove shortcut par that reference Parameter class

### DIFF
--- a/holopy/fitting/__init__.py
+++ b/holopy/fitting/__init__.py
@@ -35,5 +35,5 @@ The fitting module is used to:
 
 from .fit import fit, rsq, chisq, FitResult, make_subset_data
 from .model import Model, Parametrization
-from .parameter import Parameter, par, ComplexParameter
+from .parameter import Parameter, ComplexParameter
 from .minimizer import Nmpfit

--- a/holopy/fitting/parameter.py
+++ b/holopy/fitting/parameter.py
@@ -151,6 +151,3 @@ class ComplexParameter(Parameter):
     @property
     def guess(self):
         return self.real.guess + self.imag.guess*1.0j
-
-# provide a shortcut name for Parameter since users will have to type it a lot
-par = Parameter

--- a/holopy/fitting/tests/test_minimizer.py
+++ b/holopy/fitting/tests/test_minimizer.py
@@ -24,7 +24,7 @@ import numpy as np
 from numpy.testing import assert_equal, assert_raises, assert_allclose
 from ...scattering.scatterer import Sphere, Spheres
 from ...core import detector_grid
-from .. import fit, Parameter, par, Model
+from .. import fit, Parameter, Model
 from ..minimizer import Nmpfit
 from ..errors import ParameterSpecificationError, MinimizerConvergenceFailed
 from ...core.tests.common import assert_obj_close
@@ -92,11 +92,11 @@ def test_iter_limit():
     holo = calc_holo(schema, cluster, 1.33, .66, illum_polarization=(1,0))
 
     #trying to do a fast fit:
-    guess1 = Sphere(center = (par(guess = 15, limit = [5,25]), par(15, [5, 25]), par(20, [5, 25])), r = (par(guess = .45, limit=[.4,.6])), n = 1.59)
-    guess2 = Sphere(center = (par(guess = 14, limit = [5,25]), par(14, [5, 25]), par(20, [5, 25])), r = (par(guess = .45, limit=[.4,.6])), n = 1.59)
+    guess1 = Sphere(center = (Parameter(guess = 15, limit = [5,25]), Parameter(15, [5, 25]), Parameter(20, [5, 25])), r = (Parameter(guess = .45, limit=[.4,.6])), n = 1.59)
+    guess2 = Sphere(center = (Parameter(guess = 14, limit = [5,25]), Parameter(14, [5, 25]), Parameter(20, [5, 25])), r = (Parameter(guess = .45, limit=[.4,.6])), n = 1.59)
     par_s = Spheres([guess1,guess2])
 
-    model = Model(par_s, calc_holo, 1.33, .66, illum_polarization=(1, 0), alpha = par(.6, [.1, 1]))
+    model = Model(par_s, calc_holo, 1.33, .66, illum_polarization=(1, 0), alpha = Parameter(.6, [.1, 1]))
     warnings.simplefilter("always")
     result = fit(model, holo, minimizer = Nmpfit(maxiter=2))
     assert_obj_close(gold_fit_dict,result.parameters,rtol=1e-6)

--- a/holopy/fitting/tests/test_model.py
+++ b/holopy/fitting/tests/test_model.py
@@ -25,7 +25,8 @@ from nose.plugins.attrib import attr
 from numpy.testing import assert_equal
 from holopy.scattering.theory import Mie
 from holopy.scattering.scatterer import Sphere, Spheres
-from holopy.fitting import par, Model, ComplexParameter, Parametrization
+from holopy.fitting import Model, ComplexParameter, Parametrization
+from holopy.fitting import Parameter as par
 from holopy.core.tests.common import assert_read_matches_write
 from holopy.scattering.calculations import calc_holo
 

--- a/holopy/fitting/tests/test_parameter.py
+++ b/holopy/fitting/tests/test_parameter.py
@@ -19,18 +19,13 @@
 
 from numpy.testing import assert_raises, assert_equal
 
-from ..parameter import Parameter, par, ComplexParameter
+from ..parameter import ComplexParameter
+from ..parameter import Parameter as par
 from ..errors import GuessOutOfBoundsError
 from ...core.tests.common import assert_obj_close
 
 
 def test_parameter():
-    # basic parameter
-    p1 = Parameter(guess = 5, limit = [4, 6])
-    # now make a par using shorthands
-    p2 = par(5, [4,6])
-    # they should be the same
-    assert_obj_close(p1, p2)
 
     p3 = par(limit = 7)
 


### PR DESCRIPTION
This was confusing since ``par`` and ``Parameter`` pointed to the same thing, but both names were sometimes used. The previous rationale was that users would need to type Parameter a lot so it was given a shortcut. This is no longer relevant since fitting has been replaced with Bayesian Inference, which uses a higher level Prior class. 