### PR TITLE
Replaced obsolete email addresses in moduleauthor:: headers for myself

### DIFF
--- a/holopy/__init__.py
+++ b/holopy/__init__.py
@@ -23,7 +23,7 @@ light scattering, fitting scattering models to data, and visualizing
 images and calculations.
 
 .. moduleauthor:: Tom Dimiduk <tdimiduk@physics.harvard.edu>
-.. moduleauthor:: Jerome Fung <fung@physics.harvard.edu>
+.. moduleauthor:: Jerome Fung <jerome.fung@post.harvard.edu>
 .. moduleauthor:: Rebecca W. Perry <rperry@seas.harvard.edu>
 .. moduleauthor:: Ryan McGorty <mcgorty@fas.harvard.edu>
 .. moduleauthor:: Vinothan N. Manoharan <vnm@seas.harvard.edu>

--- a/holopy/core/process/__init__.py
+++ b/holopy/core/process/__init__.py
@@ -23,7 +23,7 @@ reconstructions.
 .. moduleauthor:: Ryan McGorty <mcgorty@fas.harvard.edu>
 .. moduleauthor:: Vinothan N. Manoharan <vnm@seas.harvard.edu>
 .. moduleauthor:: Tom G. Dimiduk <tdimiduk@physics.harvard.edu>
-.. moduleauthor:: Jerome Fung <fung@physics.harvard.edu>
+.. moduleauthor:: Jerome Fung <jerome.fung@post.harvard.edu>
 '''
 
 

--- a/holopy/core/process/centerfinder.py
+++ b/holopy/core/process/centerfinder.py
@@ -33,7 +33,7 @@ F. C. Cheong, B. Sun, R. Dreyfus, J. Amato-Grill, K. Xiao, L. Dixon
 video microscopy, Optics Express 17, 13071-13079 (2009).
 
 .. moduleauthor:: Rebecca W. Perry <rperry@seas.harvard.edu>
-.. moduleauthor:: Jerome Fung <fung@physics.harvard.edu>
+.. moduleauthor:: Jerome Fung <jerome.fung@post.harvard.edu>
 """
 
 import numpy as np

--- a/holopy/core/process/fourier.py
+++ b/holopy/core/process/fourier.py
@@ -21,7 +21,7 @@ Handles Fourier transforms of HoloPy images by using scipy's fftpack. Tries to c
 .. moduleauthor:: Ryan McGorty <mcgorty@fas.harvard.edu>
 .. moduleauthor:: Vinothan N. Manoharan <vnm@seas.harvard.edu>
 .. moduleauthor:: Tom G. Dimiduk <tdimiduk@physics.harvard.edu>
-.. moduleauthor:: Jerome Fung <fung@physics.harvard.edu>
+.. moduleauthor:: Jerome Fung <jerome.fung@post.harvard.edu>
 """
 
 

--- a/holopy/core/process/img_proc.py
+++ b/holopy/core/process/img_proc.py
@@ -22,7 +22,7 @@ or detrending
 .. moduleauthor:: Ryan McGorty <mcgorty@fas.harvard.edu>
 .. moduleauthor:: Vinothan N. Manoharan <vnm@seas.harvard.edu>
 .. moduleauthor:: Tom G. Dimiduk <tdimiduk@physics.harvard.edu>
-.. moduleauthor:: Jerome Fung <fung@physics.harvard.edu>
+.. moduleauthor:: Jerome Fung <jerome.fung@post.harvard.edu>
 """
 
 from ..errors import BadImage

--- a/holopy/fitting/__init__.py
+++ b/holopy/fitting/__init__.py
@@ -27,7 +27,7 @@ The fitting module is used to:
 3. Fit model to timeseries -> list of :class:`.FitResult` objects
 
 .. moduleauthor:: Thomas G. Dimiduk <tdimiduk@physics.harvard.edu>
-.. moduleauthor:: Jerome Fung <fung@physics.harvard.edu>
+.. moduleauthor:: Jerome Fung <jerome.fung@post.harvard.edu>
 .. moduleauthor:: Rebecca W. Perry <rperry@seas.harvard.edu>
 .. moduleauthor:: Vinothan N. Manoharan <vnm@seas.harvard.edu>
 

--- a/holopy/fitting/third_party/nmpfit.py
+++ b/holopy/fitting/third_party/nmpfit.py
@@ -22,7 +22,7 @@ Levenberg-Marquardt minimizer obtained from
 
 http://stsdas.stsci.edu/pyraf/stscidocs/pytools_pkg/pytools_api/pytools.nmpfit-module.html
 
-The source code above was modified by Jerome Fung (fung@physics.harvard.edu) to
+The source code above was modified by Jerome Fung (jerome.fung@post.harvard.edu) to
 be independent of the rest of the stsci_python package, since holopy does
 
 use Numeric.

--- a/holopy/scattering/__init__.py
+++ b/holopy/scattering/__init__.py
@@ -32,7 +32,7 @@ The HoloPy scattering module is used to:
    :class:`~holopy.core.marray.Marray` object
 
 .. moduleauthor:: Thomas G. Dimiduk <tdimiduk@physics.harvard.edu>
-.. moduleauthor:: Jerome Fung <fung@physics.harvard.edu>
+.. moduleauthor:: Jerome Fung <jerome.fung@post.harvard.edu>
 .. moduleauthor:: Ryan McGorty <mcgorty@fas.harvard.edu>
 .. moduleauthor:: Rebecca W. Perry <rperry@seas.harvard.edu>
 .. moduleauthor:: Vinothan N. Manoharan <vnm@seas.harvard.edu>

--- a/holopy/scattering/tests/test_lowlevel.py
+++ b/holopy/scattering/tests/test_lowlevel.py
@@ -31,7 +31,7 @@ of those fail, failures in these low-level tests will help pin
 down the problem.
 
 
-.. moduleauthor:: Jerome Fung <fung@physics.harvard.edu>
+.. moduleauthor:: Jerome Fung <jerome.fung@post.harvard.edu>
 '''
 
 

--- a/holopy/scattering/theory/__init__.py
+++ b/holopy/scattering/theory/__init__.py
@@ -23,7 +23,7 @@ All theories have a common interface defined by
 
 
 .. moduleauthor:: Thomas G. Dimiduk <tdimiduk@physics.harvard.edu>
-.. moduleauthor:: Jerome Fung <fung@physics.harvard.edu>
+.. moduleauthor:: Jerome Fung <jerome.fung@post.harvard.edu>
 .. moduleauthor:: Ryan McGorty <mcgorty@fas.harvard.edu>
 .. moduleauthor:: Rebecca W. Perry <rperry@seas.harvard.edu>
 .. moduleauthor:: Vinothan N. Manoharan <vnm@seas.harvard.edu>

--- a/holopy/scattering/theory/mie.py
+++ b/holopy/scattering/theory/mie.py
@@ -22,7 +22,7 @@ spheres. Uses full radial dependence of spherical Hankel functions for
 scattered field.
 
 .. moduleauthor:: Thomas G. Dimiduk <tdimiduk@physics.harvard.edu>
-.. moduleauthor:: Jerome Fung <fung@physics.harvard.edu>
+.. moduleauthor:: Jerome Fung <jerome.fung@post.harvard.edu>
 .. moduleauthor:: Vinothan N. Manoharan <vnm@seas.harvard.edu>
 '''
 

--- a/holopy/scattering/theory/mie_f/__init__.py
+++ b/holopy/scattering/theory/mie_f/__init__.py
@@ -19,6 +19,6 @@
 Fortran extension module for calculating cluster holograms using tmatrix
 scattering theory.
 
-.. moduleauthor:: Jerome Fung <fung@physics.harvard.edu>
+.. moduleauthor:: Jerome Fung <jerome.fung@post.harvard.edu>
 """
 

--- a/holopy/scattering/theory/mie_f/mie_specfuncs.py
+++ b/holopy/scattering/theory/mie_f/mie_specfuncs.py
@@ -33,7 +33,7 @@ cross sections in a stratified sphere," Applied Optics 29, 1551-1559, (1990).
 Yang, "Improved recursive algorithm for light scattering by a multilayered
 sphere," Applied Optics 42, 1710-1720, (1993).
 
-.. moduleauthor:: Jerome Fung <fung@physics.harvard.edu>
+.. moduleauthor:: Jerome Fung <jerome.fung@post.harvard.edu>
 """
 
 

--- a/holopy/scattering/theory/mie_f/miescatlib.py
+++ b/holopy/scattering/theory/mie_f/miescatlib.py
@@ -21,7 +21,7 @@ MieScatLib.py
 
 Library of code to do Mie scattering calculations.
 
-.. moduleauthor:: Jerome Fung <fung@physics.harvard.edu>
+.. moduleauthor:: Jerome Fung <jerome.fung@post.harvard.edu>
 '''
 
 import numpy as np

--- a/holopy/scattering/theory/multisphere.py
+++ b/holopy/scattering/theory/multisphere.py
@@ -22,7 +22,7 @@ modified version of Daniel Mackowski's SCSMFO1B.FOR.  Uses full radial
 dependence of spherical Hankel functions for the scattered field.
 
 .. moduleauthor:: Vinothan N. Manoharan <vnm@seas.harvard.edu>
-.. moduleauthor:: Jerome Fung <fung@physics.harvard.edu>
+.. moduleauthor:: Jerome Fung <jerome.fung@post.harvard.edu>
 .. moduleauthor:: Thomas G. Dimiduk <tdimiduk@physics.harvard.edu>
 """
 

--- a/holopy/scattering/theory/scatteringtheory.py
+++ b/holopy/scattering/theory/scatteringtheory.py
@@ -19,7 +19,7 @@
 Base class for scattering theories.  Implements python-based
 calc_intensity and calc_holo, based on subclass's calc_field
 
-.. moduleauthor:: Jerome Fung <fung@physics.harvard.edu>
+.. moduleauthor:: Jerome Fung <jerome.fung@post.harvard.edu>
 .. moduleauthor:: Vinothan N. Manoharan <vnm@seas.harvard.edu>
 .. moduleauthor:: Thomas G. Dimiduk <tdimiduk@physics.harvard.edu>
 """


### PR DESCRIPTION
Replaced fung@physics.harvard.edu email address with jerome.fung@post.harvard.edu in all module author headers.