### PR TITLE
Add Windows SkipTests

### DIFF
--- a/holopy/scattering/tests/test_dda.py
+++ b/holopy/scattering/tests/test_dda.py
@@ -27,7 +27,7 @@ import numpy as np
 from nose.tools import with_setup
 from nose.plugins.attrib import attr
 from nose.plugins.skip import SkipTest
-import os.path
+import os
 
 
 from ...scattering.errors import DependencyMissing
@@ -69,6 +69,9 @@ def test_DDA_sphere():
 
 @with_setup(setup=setup_optics, teardown=teardown_optics)
 def test_dda_2_cpu():
+    if os.name == 'nt':
+        raise Skiptest()
+
     sc = Sphere(n=1.59, r=3e-1, center=(1, -1, 30))
     mie_holo = calc_holo(schema, sc, index, wavelen)
     try:

--- a/holopy/scattering/tests/test_lowlevel.py
+++ b/holopy/scattering/tests/test_lowlevel.py
@@ -42,6 +42,7 @@ from numpy.testing import assert_allclose
 import numpy as np
 from numpy import sqrt, dot, pi, conj, real, imag, exp
 from nose.plugins.attrib import attr
+from nose.plugins.skip import SkipTest
 from scipy.special import spherical_jn, spherical_yn
 
 from ..theory.mie_f import mieangfuncs, miescatlib, multilayer_sphere_lib, \
@@ -183,6 +184,9 @@ def test_scattered_field_from_asm():
 
 @attr('medium')
 def test_mie_internal_coeffs():
+    if os.name == 'nt':
+        raise SkipTest()
+
     m = 1.5 + 0.1j
     x = 50.
     n_stop = miescatlib.nstop(x)


### PR DESCRIPTION
Skip a test to run multicore DDA since it asks user for login credentials and that cannot be automated.

Skip a test that calls scipy.special.spherical_jn and scipy.special.spherical_yn with complex numbers since they are not compiled properly on Windows for conda.