### PR TITLE
add nose plugin to treat warnings as exceptions

### DIFF
--- a/docs/source/users/dev_tutorial.rst
+++ b/docs/source/users/dev_tutorial.rst
@@ -17,12 +17,11 @@ Download or clone the latest version of HoloPy from Git Hub at `https://github.c
 Let's say you downloaded or cloned HoloPy to
 ``/home/me/holopy``. Then open a terminal, ``cd`` to ``/home/me/holopy`` and run::
 
-    python setup.py build_ext --inplace
+    python setup.py develop
 
 This puts the extensions inside the source tree, so that you can work
-directly from ``/home/me/holopy``.  You will need to add
-``/home/me/holopy`` to your python_path for python to find the
-module when you import it.
+directly from ``/home/me/holopy`` and have the changes reflected in the version
+of HoloPy that you import into python.
 
 **Note for Mac users:** gfortran may put its library in a place python can't find it. If you get errors including something like ``can't find /usr/local/libgfortran.3.dynlib`` you can symlink them in from your install. You can do this by running::
 

--- a/holopy/core/tests/common.py
+++ b/holopy/core/tests/common.py
@@ -18,20 +18,35 @@
 
 import tempfile
 import os
+import warnings
 import types
 import inspect
 import yaml
 import shutil
-from numpy.testing import assert_equal, assert_allclose
 import pickle
 from collections import OrderedDict
+
 import xarray as xr
+from numpy.testing import assert_equal, assert_allclose
+from nose.plugins import Plugin
 
 from holopy.core.io import load, save, get_example_data
 
-# tests should fail if they give warnings
-import warnings
-warnings.simplefilter("error")
+
+class HoloPyCatchWarnings(Plugin):
+    name='holopycatchwarnings'
+
+    def options(self, parser, env=os.environ):
+        super(HoloPyCatchWarnings, self).options(parser, env=env)
+
+    def configure(self, options, conf):
+        super(HoloPyCatchWarnings, self).configure(options, conf)
+        if not self.enabled:
+            return
+
+    def beforeTest(self, test):
+        warnings.simplefilter("error")
+
 
 def assert_read_matches_write(o):
     with tempfile.NamedTemporaryFile(suffix='.h5') as tempf:

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ h5py
 matplotlib
 xarray>=0.10.0
 h5netcdf
+nose

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[nosetests]
+with-holopycatchwarnings=1

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ from numpy.distutils.core import setup, Extension
 
 HOLOPY_NOSE_PLUGIN_LOCATION = ('holopycatchwarnings = '
                                'holopy.core.tests.common:HoloPyCatchWarnings')
-print(HOLOPY_NOSE_PLUGIN_LOCATION)
 
 hp_root = os.path.dirname(os.path.realpath(sys.argv[0]))
 

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,9 @@ from os.path import join
 import nose
 from numpy.distutils.core import setup, Extension
 
-HOLOPY_NOSE_PLUGIN_LOCATION =
-    'holopycatchwarnings = holopy.core.tests.common:HoloPyCatchWarnings'
+HOLOPY_NOSE_PLUGIN_LOCATION = ('holopycatchwarnings = '
+                               'holopy.core.tests.common:HoloPyCatchWarnings')
+print(HOLOPY_NOSE_PLUGIN_LOCATION)
 
 hp_root = os.path.dirname(os.path.realpath(sys.argv[0]))
 

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,12 @@ import setuptools
 import os
 import sys
 from os.path import join
+
+import nose
 from numpy.distutils.core import setup, Extension
 
+HOLOPY_NOSE_PLUGIN_LOCATION =
+    'holopycatchwarnings = holopy.core.tests.common:HoloPyCatchWarnings'
 
 hp_root = os.path.dirname(os.path.realpath(sys.argv[0]))
 
@@ -78,4 +82,5 @@ if __name__ == "__main__":
           url='http://manoharan.seas.harvard.edu/holopy',
           license='GNU GPL',
           test_suite='nose.collector',
+          entry_points = {'nose.plugins.0.10': HOLOPY_NOSE_PLUGIN_LOCATION},
           package=['HoloPy'])


### PR DESCRIPTION
There are a few changes here:

1) A nose plugin is defined in `holopy.core.tests.common.py` that raises exceptions when warnings are encountered when running tests.

2) When `setup.py` is run, this plugin is also installed globally (unfortunately this is how nose handles plugins; nose2 has fixed this). This will work if `setup.py` is run with either `install` or `develop` 
commands. 
**edit**: it will not work when running `python setup.py build_ext --inplace` as we previously recommended in our documentation. see #303.

3) The new `setup.cfg` file runs nosetests with the plugin activated whenever nosetests is run from the holopy root directory. Unfortunately it won't activate automatically if run from subdirectories.

4) nose is now imported in `setup.py`, and so it has become a build dependency and not just a test dependency. 