### PR TITLE
Emcee3+holopy3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - 3.6
 
 env:
-  - DEPS="scipy pyyaml pillow pandas h5py=2.9 sphinx matplotlib nose emcee=2.2.1 schwimmbad numpy xarray h5netcdf yaml<0.2"
+  - DEPS="scipy pyyaml pillow pandas h5py=2.9 sphinx matplotlib nose emcee schwimmbad numpy xarray h5netcdf yaml<0.2"
 
 branches:
   except:

--- a/holopy/inference/emcee.py
+++ b/holopy/inference/emcee.py
@@ -133,14 +133,15 @@ class TemperedStrategy(EmceeStrategy):
 
 def emcee_samples_DataArray(sampler, parameters):
     acceptance_fraction = sampler.acceptance_fraction.mean()
-    return xr.DataArray(sampler.chain, dims=['walker', 'chain', 'parameter'],
+    return xr.DataArray(sampler.get_chain(),
+                        dims=['walker', 'chain', 'parameter'],
                         coords={'parameter': [p.name for p in parameters]},
                         attrs={"acceptance_fraction": acceptance_fraction})
 
 
 def emcee_lnprobs_DataArray(sampler):
     acceptance_fraction = sampler.acceptance_fraction.mean()
-    return xr.DataArray(sampler.lnprobability, dims=['walker', 'chain'],
+    return xr.DataArray(sampler.get_log_prob(), dims=['walker', 'chain'],
                         attrs={"acceptance_fraction": acceptance_fraction})
 
 
@@ -164,4 +165,3 @@ def sample_emcee(model, data, nwalkers, nsamples, walker_initial_pos,
         pool.close()
 
     return sampler
-

--- a/holopy/inference/tests/test_emcee.py
+++ b/holopy/inference/tests/test_emcee.py
@@ -52,9 +52,9 @@ class testEmcee(unittest.TestCase):
         mod = SimpleModel(1)
         p0 = np.linspace(0, 1, nwalkers*ndim).reshape((nwalkers, ndim))
         r = sample_emcee(mod, data, nwalkers, 500, p0, parallel=None, seed=40)
-        should_be_onehalf = r.chain[r.lnprobability == r.lnprobability.max()]
+        should_be_onehalf = r.get_chain()[r.get_log_prob()
+                                          == r.get_log_prob().max()]
         assert_allclose(should_be_onehalf, .5, rtol=.001)
-
 
     @attr("fast")
     def test_EmceeStrategy(self):

--- a/holopy/inference/tests/test_emcee.py
+++ b/holopy/inference/tests/test_emcee.py
@@ -60,7 +60,7 @@ class testEmcee(unittest.TestCase):
     def test_EmceeStrategy(self):
         data = np.array(.5)
         mod = SimpleModel(1)
-        strat = EmceeStrategy(10, 5, None, None, seed=48)
+        strat = EmceeStrategy(10, 15, None, None, seed=48)
         r = strat.sample(mod, data)
         assert_allclose(r._parameters, .5, rtol=.001)
 
@@ -77,9 +77,7 @@ class TestSubsetTempering(unittest.TestCase):
             warnings.simplefilter('ignore')
             inference_result = strat.sample(mod, holo)
         desired_alpha = np.array([0.650348])
-        is_ok = np.allclose(
-            inference_result._parameters, desired_alpha, rtol=1e-3)
-        self.assertTrue(is_ok)
+        assert_allclose(inference_result._parameters, desired_alpha, rtol=5e-3)
 
     @attr("slow")
     def test_perfectlens_subset_tempering(self):


### PR DESCRIPTION
This PR
- fixes the deprecation warnings triggered by emcee's 3.0 API changes
- fixes the two MCMC tests that have been failing for some of us.
- changes some of travis's pinnings per #299
- closes #310