### PR TITLE
Quick hack for saving reconstruction volumes

### DIFF
--- a/holopy/core/__init__.py
+++ b/holopy/core/__init__.py
@@ -24,5 +24,5 @@
 
 from holopy.core.metadata import (detector_grid, detector_points,
                                   update_metadata, copy_metadata)
-from holopy.core.io import (load, load_image, save, save_image,
+from holopy.core.io import (load, load_image, save, save_image, save_images,
                             show, test_display)

--- a/holopy/core/io/__init__.py
+++ b/holopy/core/io/__init__.py
@@ -15,7 +15,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with HoloPy.  If not, see <http://www.gnu.org/licenses/>.
-from holopy.core.io.io import (load, load_image, save, save_image,
-    get_example_data, get_example_data_path, load_average)
-from holopy.core.io.vis import (show, test_display, display_image,
-                                show_scatterer_slices)
+from holopy.core.io.io import (
+    load, load_image, save, save_image, save_images, get_example_data,
+    get_example_data_path, load_average)
+from holopy.core.io.vis import (
+    show, test_display, display_image, show_scatterer_slices)

--- a/holopy/core/io/io.py
+++ b/holopy/core/io/io.py
@@ -323,12 +323,12 @@ def save_image(filename, im, scaling='auto', depth=8):
 
     Parameters
     ----------
-    im : ndarray or :class:`holopy.image.Image`
-        image to save.
     filename : basestring
         filename in which to save image. If im is an image the
         function should default to the image's name field if no
         filename is specified
+    im : ndarray or :class:`holopy.image.Image`
+        image to save.
     scaling : 'auto', None, or (Int, Int)
         How the image should be scaled for saving. Ignored for float
         output. It defaults to auto, use the full range of the output
@@ -380,19 +380,19 @@ def save_image(filename, im, scaling='auto', depth=8):
         pilimage.fromarray(im).save(filename)
 
 
-def save_images(ims, filenames, scaling='auto', depth=8):
+def save_images(filenames, ims, scaling='auto', depth=8):
     """
     Saves a volume as separate images (think of reconstruction volumes).
 
     Parameters
     ----------
-    ims : ndarray or :class:`holopy.image.Image`
-        Images to save, with separate z-coordinates from which they each will
-        be selected.
     filenames : str
         List of filenames. There have to be the same number of filenames as of
         images to save. Each image will be saved in the corresponding file with
         the same index.
+    ims : ndarray or :class:`holopy.image.Image`
+        Images to save, with separate z-coordinates from which they each will
+        be selected.
     scaling : 'auto', None, or (Int, Int)
         How the images should be scaled for saving. Ignored for float output.
         It defaults to auto, use the full range of the output format. Other
@@ -412,18 +412,18 @@ def save_images(ims, filenames, scaling='auto', depth=8):
     for i, im in enumerate(ims): _save_im(im, filenames[i], depth)
 
 
-def _save_im(im, filename, depth=8):
+def _save_im(filename, im, depth=8):
     """
     Internal single-image-save-method to be used in save_images. Maybe it can
     be merged with save_image.
 
     Parameters
     ----------
-    im : ndarray or :class:`holopy.image.Image`
-        Image to save.
     filename : basestring
         Filename in which to save image. If im is an image the function should
         default to the image's name field if no filename is specified
+    im : ndarray or :class:`holopy.image.Image`
+        Image to save.
     depth : 8, 16 or 'float'
         What type of image to save. Options other than 8bit may not be
         supported for many image types. You probably don't want to save 8bit

--- a/holopy/core/io/io.py
+++ b/holopy/core/io/io.py
@@ -379,6 +379,94 @@ def save_image(filename, im, scaling='auto', depth=8):
     else:
         pilimage.fromarray(im).save(filename)
 
+def save_images(filenames, ims, scaling='auto', depth = 8):
+    """
+    Saves a volume as separate images (think of reconstruction volumes).
+
+    Parameters
+    ----------
+    ims : ndarray or :class:`holopy.image.Image`
+        Images to save, with separate z-coordinates from which they each will be
+        selected.
+    filename : str
+        Filename in which to save image. Has to contain a format placeholder for
+        the z-values. E.g. "testfile%f.png"
+    scaling : 'auto', None, or (Int, Int)
+        How the images should be scaled for saving. Ignored for float output. It
+        defaults to auto, use the full range of the output format. Other options
+        are None, meaning no scaling, or a pair of integers specifying the
+        values which should be set to the maximum and minimum values of the
+        image format.
+    depth : 8, 16 or 'float'
+        What type of image to save. Options other than 8bit may not be supported
+        for many image types. You probably don't want to save 8bit images
+        without some kind of scaling.
+    """
+    # TODO: Here could be a check whether ims has the correct format.
+    ims = display_image(ims, scaling)
+    for im in ims:
+        z = im.z.values.item(0) # TODO: There must be a nicer way…
+        _save_im(filenames % z, im, scaling, depth)
+
+def _save_im(filename, im, scaling='auto', depth=8):
+    """
+    Internal single-image-save-method to be used in save_images. Maybe it can be
+    merged with save_image.
+
+    Parameters
+    ----------
+    im : ndarray or :class:`holopy.image.Image`
+        Image to save.
+    filename : basestring
+        Filename in which to save image. If im is an image the function should
+        default to the image's name field if no filename is specified
+    scaling : 'auto', None, or (Int, Int)
+        How the images should be scaled for saving. Ignored for float output. It
+        defaults to auto, use the full range of the output format. Other options
+        are None, meaning no scaling, or a pair of integers specifying the
+        values which should be set to the maximum and minimum values of the
+        image format.
+    depth : 8, 16 or 'float'
+        What type of image to save. Options other than 8bit may not be supported
+        for many image types. You probably don't want to save 8bit images
+        without some kind of scaling.
+    """
+    # if we don't have an extension, default to tif
+    if os.path.splitext(filename)[1] is '':
+        filename += '.tif'
+
+    metadat=False
+    if os.path.splitext(filename)[1] in tiflist:
+        if im.name is None:
+            im.name=os.path.splitext(os.path.split(filename)[-1])[0]
+        metadat = pack_attrs(im, do_spacing = True)
+        # import ifd2 - hidden here since it doesn't play nice in some cases.
+        from PIL.TiffImagePlugin import ImageFileDirectory_v2 as ifd2
+        tiffinfo = ifd2()
+        # place metadata in the 'imagedescription' field of the tiff metadata
+        tiffinfo[270] = yaml.dump(metadat, default_flow_style=True)
+
+    im = im.values
+
+    if depth is not 'float':
+        if depth is 8:
+            depth = 8
+            typestr = 'uint8'
+        elif depth is 16 or depth is 32:
+            depth = depth-1
+            typestr = 'int' + str(depth)
+        else:
+            raise Error("Unknown image depth")
+
+        if im.max() <= 1:
+            im = im * ((2**depth)-1) + .499999
+            im = im.astype(typestr)
+
+    if metadat:
+        pilimage.fromarray(im).save(filename, tiffinfo=tiffinfo)
+    else:
+        pilimage.fromarray(im).save(filename)
+
 
 def load_average(
         filepath, refimg=None, spacing=None, medium_index=None,
@@ -508,4 +596,3 @@ class Accumulator:
             return None
         else:
             return np.sqrt(self._running_var / (self._n))
-

--- a/holopy/core/io/io.py
+++ b/holopy/core/io/io.py
@@ -380,7 +380,7 @@ def save_image(filename, im, scaling='auto', depth=8):
         pilimage.fromarray(im).save(filename)
 
 
-def save_images(filenames, ims, scaling='auto', depth=8):
+def save_images(ims, filenames, scaling='auto', depth=8):
     """
     Saves a volume as separate images (think of reconstruction volumes).
 
@@ -389,9 +389,10 @@ def save_images(filenames, ims, scaling='auto', depth=8):
     ims : ndarray or :class:`holopy.image.Image`
         Images to save, with separate z-coordinates from which they each will
         be selected.
-    filename : str
-        Filename in which to save image. Has to contain a format placeholder
-        for the z-values. E.g. "testfile%f.png"
+    filenames : str
+        List of filenames. There have to be the same number of filenames as of
+        images to save. Each image will be saved in the corresponding file with
+        the same index.
     scaling : 'auto', None, or (Int, Int)
         How the images should be scaled for saving. Ignored for float output.
         It defaults to auto, use the full range of the output format. Other
@@ -404,13 +405,14 @@ def save_images(filenames, ims, scaling='auto', depth=8):
         images without some kind of scaling.
     """
     # TODO: Here could be a check whether ims has the correct format.
+    if len(ims) != len(filenames):
+        raise Error("Not enough filenames or images provided.")
+
     ims = display_image(ims, scaling)
-    for im in ims:
-        z = im.z.values.item(0)  # TODO: There must be a nicer way…
-        _save_im(filenames % z, im, scaling, depth)
+    for i, im in enumerate(ims): _save_im(im, filenames[i], scaling, depth)
 
 
-def _save_im(filename, im, scaling='auto', depth=8):
+def _save_im(im, filename, scaling='auto', depth=8):
     """
     Internal single-image-save-method to be used in save_images. Maybe it can
     be merged with save_image.

--- a/holopy/core/io/io.py
+++ b/holopy/core/io/io.py
@@ -373,8 +373,9 @@ def save_images(filenames, ims, scaling='auto', depth=8):
     if len(ims) != len(filenames):
         raise Error("Not enough filenames or images provided.")
 
-    ims = display_image(ims, scaling)
-    for i, im in enumerate(ims): _save_im(im, filenames[i], depth)
+    for image_raw, filename in zip(ims, filenames):
+        image_displayed = display_image(image_raw, scaling)
+        _save_im(filename, image_displayed, depth)
 
 
 def _save_im(filename, im, depth=8):

--- a/holopy/core/io/io.py
+++ b/holopy/core/io/io.py
@@ -369,9 +369,8 @@ def save_images(filenames, ims, scaling='auto', depth=8):
         supported for many image types. You probably don't want to save 8bit
         images without some kind of scaling.
     """
-    # TODO: Here could be a check whether ims has the correct format.
     if len(ims) != len(filenames):
-        raise Error("Not enough filenames or images provided.")
+        raise ValueError("Not enough filenames or images provided.")
 
     for image_raw, filename in zip(ims, filenames):
         image_displayed = display_image(image_raw, scaling)

--- a/holopy/core/io/io.py
+++ b/holopy/core/io/io.py
@@ -386,7 +386,7 @@ def save_images(filenames, ims, scaling='auto', depth=8):
 
     Parameters
     ----------
-    filenames : str
+    filenames : list
         List of filenames. There have to be the same number of filenames as of
         images to save. Each image will be saved in the corresponding file with
         the same index.

--- a/holopy/core/io/io.py
+++ b/holopy/core/io/io.py
@@ -342,42 +342,7 @@ def save_image(filename, im, scaling='auto', depth=8):
 
     """
     im = display_image(im, scaling)
-
-    # if we don't have an extension, default to tif
-    if os.path.splitext(filename)[1] is '':
-        filename += '.tif'
-
-    metadat=False
-    if os.path.splitext(filename)[1] in tiflist:
-        if im.name is None:
-            im.name=os.path.splitext(os.path.split(filename)[-1])[0]
-        metadat = pack_attrs(im, do_spacing = True)
-        # import ifd2 - hidden here since it doesn't play nice in some cases.
-        from PIL.TiffImagePlugin import ImageFileDirectory_v2 as ifd2
-        tiffinfo = ifd2()
-        # place metadata in the 'imagedescription' field of the tiff metadata
-        tiffinfo[270] = yaml.dump(metadat, default_flow_style=True)
-
-    im = im.values[0]
-
-    if depth is not 'float':
-        if depth is 8:
-            depth = 8
-            typestr = 'uint8'
-        elif depth is 16 or depth is 32:
-            depth = depth-1
-            typestr = 'int' + str(depth)
-        else:
-            raise Error("Unknown image depth")
-
-        if im.max() <= 1:
-            im = im * ((2**depth)-1) + .499999
-            im = im.astype(typestr)
-
-    if metadat:
-        pilimage.fromarray(im).save(filename, tiffinfo=tiffinfo)
-    else:
-        pilimage.fromarray(im).save(filename)
+    _save_im(filename, im, depth)
 
 
 def save_images(filenames, ims, scaling='auto', depth=8):
@@ -445,6 +410,7 @@ def _save_im(filename, im, depth=8):
         tiffinfo[270] = yaml.dump(metadat, default_flow_style=True)
 
     im = im.values
+    if im.ndim > 2: im = im[0]
 
     if depth is not 'float':
         if depth is 8:

--- a/holopy/core/io/io.py
+++ b/holopy/core/io/io.py
@@ -395,12 +395,11 @@ def _save_im(filename, im, depth=8):
         images without some kind of scaling.
     """
     # if we don't have an extension, default to tif
-    if os.path.splitext(filename)[1] is '':
-        filename += '.tif'
+    if os.path.splitext(filename)[1] == '': filename += '.tif'
 
     metadat = False
     if os.path.splitext(filename)[1] in tiflist:
-        if im.name is None:
+        if im.name == None:
             im.name = os.path.splitext(os.path.split(filename)[-1])[0]
         metadat = pack_attrs(im, do_spacing=True)
         # import ifd2 - hidden here since it doesn't play nice in some cases.
@@ -412,11 +411,11 @@ def _save_im(filename, im, depth=8):
     im = im.values
     if im.ndim > 2: im = im[0]
 
-    if depth is not 'float':
-        if depth is 8:
+    if depth != 'float':
+        if depth == 8:
             depth = 8
             typestr = 'uint8'
-        elif depth is 16 or depth is 32:
+        elif depth == 16 or depth == 32:
             depth = depth-1
             typestr = 'int' + str(depth)
         else:

--- a/holopy/core/io/io.py
+++ b/holopy/core/io/io.py
@@ -409,10 +409,10 @@ def save_images(ims, filenames, scaling='auto', depth=8):
         raise Error("Not enough filenames or images provided.")
 
     ims = display_image(ims, scaling)
-    for i, im in enumerate(ims): _save_im(im, filenames[i], scaling, depth)
+    for i, im in enumerate(ims): _save_im(im, filenames[i], depth)
 
 
-def _save_im(im, filename, scaling='auto', depth=8):
+def _save_im(im, filename, depth=8):
     """
     Internal single-image-save-method to be used in save_images. Maybe it can
     be merged with save_image.
@@ -424,12 +424,6 @@ def _save_im(im, filename, scaling='auto', depth=8):
     filename : basestring
         Filename in which to save image. If im is an image the function should
         default to the image's name field if no filename is specified
-    scaling : 'auto', None, or (Int, Int)
-        How the images should be scaled for saving. Ignored for float output.
-        It defaults to auto, use the full range of the output format. Other
-        options are None, meaning no scaling, or a pair of integers specifying
-        the values which should be set to the maximum and minimum values of the
-        image format.
     depth : 8, 16 or 'float'
         What type of image to save. Options other than 8bit may not be
         supported for many image types. You probably don't want to save 8bit

--- a/holopy/core/io/io.py
+++ b/holopy/core/io/io.py
@@ -379,39 +379,41 @@ def save_image(filename, im, scaling='auto', depth=8):
     else:
         pilimage.fromarray(im).save(filename)
 
-def save_images(filenames, ims, scaling='auto', depth = 8):
+
+def save_images(filenames, ims, scaling='auto', depth=8):
     """
     Saves a volume as separate images (think of reconstruction volumes).
 
     Parameters
     ----------
     ims : ndarray or :class:`holopy.image.Image`
-        Images to save, with separate z-coordinates from which they each will be
-        selected.
+        Images to save, with separate z-coordinates from which they each will
+        be selected.
     filename : str
-        Filename in which to save image. Has to contain a format placeholder for
-        the z-values. E.g. "testfile%f.png"
+        Filename in which to save image. Has to contain a format placeholder
+        for the z-values. E.g. "testfile%f.png"
     scaling : 'auto', None, or (Int, Int)
-        How the images should be scaled for saving. Ignored for float output. It
-        defaults to auto, use the full range of the output format. Other options
-        are None, meaning no scaling, or a pair of integers specifying the
-        values which should be set to the maximum and minimum values of the
+        How the images should be scaled for saving. Ignored for float output.
+        It defaults to auto, use the full range of the output format. Other
+        options are None, meaning no scaling, or a pair of integers specifying
+        the values which should be set to the maximum and minimum values of the
         image format.
     depth : 8, 16 or 'float'
-        What type of image to save. Options other than 8bit may not be supported
-        for many image types. You probably don't want to save 8bit images
-        without some kind of scaling.
+        What type of image to save. Options other than 8bit may not be
+        supported for many image types. You probably don't want to save 8bit
+        images without some kind of scaling.
     """
     # TODO: Here could be a check whether ims has the correct format.
     ims = display_image(ims, scaling)
     for im in ims:
-        z = im.z.values.item(0) # TODO: There must be a nicer way…
+        z = im.z.values.item(0)  # TODO: There must be a nicer way…
         _save_im(filenames % z, im, scaling, depth)
+
 
 def _save_im(filename, im, scaling='auto', depth=8):
     """
-    Internal single-image-save-method to be used in save_images. Maybe it can be
-    merged with save_image.
+    Internal single-image-save-method to be used in save_images. Maybe it can
+    be merged with save_image.
 
     Parameters
     ----------
@@ -421,25 +423,25 @@ def _save_im(filename, im, scaling='auto', depth=8):
         Filename in which to save image. If im is an image the function should
         default to the image's name field if no filename is specified
     scaling : 'auto', None, or (Int, Int)
-        How the images should be scaled for saving. Ignored for float output. It
-        defaults to auto, use the full range of the output format. Other options
-        are None, meaning no scaling, or a pair of integers specifying the
-        values which should be set to the maximum and minimum values of the
+        How the images should be scaled for saving. Ignored for float output.
+        It defaults to auto, use the full range of the output format. Other
+        options are None, meaning no scaling, or a pair of integers specifying
+        the values which should be set to the maximum and minimum values of the
         image format.
     depth : 8, 16 or 'float'
-        What type of image to save. Options other than 8bit may not be supported
-        for many image types. You probably don't want to save 8bit images
-        without some kind of scaling.
+        What type of image to save. Options other than 8bit may not be
+        supported for many image types. You probably don't want to save 8bit
+        images without some kind of scaling.
     """
     # if we don't have an extension, default to tif
     if os.path.splitext(filename)[1] is '':
         filename += '.tif'
 
-    metadat=False
+    metadat = False
     if os.path.splitext(filename)[1] in tiflist:
         if im.name is None:
-            im.name=os.path.splitext(os.path.split(filename)[-1])[0]
-        metadat = pack_attrs(im, do_spacing = True)
+            im.name = os.path.splitext(os.path.split(filename)[-1])[0]
+        metadat = pack_attrs(im, do_spacing=True)
         # import ifd2 - hidden here since it doesn't play nice in some cases.
         from PIL.TiffImagePlugin import ImageFileDirectory_v2 as ifd2
         tiffinfo = ifd2()

--- a/holopy/core/tests/test_io.py
+++ b/holopy/core/tests/test_io.py
@@ -80,6 +80,18 @@ class TestLoadingAndSaving(unittest.TestCase):
         assert_obj_close(l, self.holo)
 
     @attr("fast")
+    def test_save_images_checks_names_and_holograms_are_same_length(self):
+        filenames_too_long = [
+            os.path.join(self.tempdir, 'dummy_filename_{}.tif'.format(i))
+            for i in range(len(self.holograms) + 1)]
+
+        self.assertRaises(
+            ValueError,
+            save_images,
+            filenames_too_long,
+            self.holograms)
+
+    @attr("fast")
     def test_save_images(self):
         filenames = [
             os.path.join(self.tempdir, f)

--- a/holopy/core/tests/test_io.py
+++ b/holopy/core/tests/test_io.py
@@ -49,6 +49,9 @@ IMAGE01_METADATA = {'spacing': 0.0851, 'medium_index': 1.33,
 class test_loading_and_saving(unittest.TestCase):
     def setUp(self):
         self.holo = get_example_data('image0001')
+        self.holograms = [get_example_data('image0001'),
+                          get_example_data('image0002'),
+                          get_example_data('image0003')]
         self.tempdir = tempfile.mkdtemp()
 
     def tearDown(self):
@@ -76,6 +79,17 @@ class test_loading_and_saving(unittest.TestCase):
         save_image(filename, self.holo, scaling=None)
         l = self.load_image_with_metadata(filename)
         assert_obj_close(l, self.holo)
+
+    @attr("fast")
+    def test_images_io(self):
+        filenames = ['image1001.tif', 'image1002.tif', 'image1003.tif']
+        for i, f in enumerate(filenames):
+            filenames[i] = os.path.join(self.tempdir, f)
+        save_images(filenames, self.holograms, scaling=None)
+
+        for holo, file in zip(self.holograms, filenames):
+            l = self.load_image_with_metadata(file)
+            assert_obj_close(l, holo)
 
     @attr("fast")
     def test_default_save_is_tif(self):
@@ -316,4 +330,3 @@ def _load_example_data_backgrounds():
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/holopy/core/tests/test_io.py
+++ b/holopy/core/tests/test_io.py
@@ -46,12 +46,11 @@ from holopy.core.tests.common import (
 IMAGE01_METADATA = {'spacing': 0.0851, 'medium_index': 1.33,
                     'illum_wavelen': 0.66, 'illum_polarization':  (1,0)}
 
-class test_loading_and_saving(unittest.TestCase):
+class TestLoadingAndSaving(unittest.TestCase):
     def setUp(self):
         self.holo = get_example_data('image0001')
         self.holograms = [get_example_data('image0001'),
-                          get_example_data('image0002'),
-                          get_example_data('image0003')]
+                          get_example_data('image0002')]
         self.tempdir = tempfile.mkdtemp()
 
     def tearDown(self):
@@ -81,15 +80,16 @@ class test_loading_and_saving(unittest.TestCase):
         assert_obj_close(l, self.holo)
 
     @attr("fast")
-    def test_images_io(self):
-        filenames = ['image1001.tif', 'image1002.tif', 'image1003.tif']
-        for i, f in enumerate(filenames):
-            filenames[i] = os.path.join(self.tempdir, f)
+    def test_save_images(self):
+        filenames = [
+            os.path.join(self.tempdir, f)
+            for f in ['dummy_filename_1.tif', 'dummy_filename_2.tif']]
+
         save_images(filenames, self.holograms, scaling=None)
 
-        for holo, file in zip(self.holograms, filenames):
-            l = self.load_image_with_metadata(file)
-            assert_obj_close(l, holo)
+        for ground_truth, filename in zip(self.holograms, filenames):
+            loaded = load(filename)
+            self.assertTrue(np.all(loaded.values ==  ground_truth.values))
 
     @attr("fast")
     def test_default_save_is_tif(self):

--- a/holopy/core/tests/test_io.py
+++ b/holopy/core/tests/test_io.py
@@ -32,7 +32,7 @@ from PIL import Image as pilimage
 from PIL.TiffImagePlugin import ImageFileDirectory_v2 as ifd2
 
 import holopy as hp
-from holopy.core import load, save, load_image, save_image
+from holopy.core import load, save, load_image, save_image, save_images
 from holopy.core.errors import NoMetadata
 from holopy.core.io import load_average, get_example_data_path
 from holopy.core.io.io import Accumulator


### PR DESCRIPTION
As referenced in #323 I wrote a quick hack to be able to save images from a reconstruction volume. There are two things to consider:

1. Maybe the created `_save_image`-method can be used for the existing `save_image`. The only difference is the `im = im.values` (note the missing index of 0) in the new method. Maybe there is some clever if-construct that is able to handle this automatically? I'm unfortunately not familiar with `xarray` at all. Maybe someone can refactor the code?

2. `save_images` has no check if the given data has the correct format. I think this is acceptable for a quick hack but not for a robust library. Maybe someone can look into this – I'm still not familiar with `xarray`.