### PR TITLE
update to get show_scatterer_slices to work

### DIFF
--- a/holopy/core/io/vis.py
+++ b/holopy/core/io/vis.py
@@ -129,7 +129,7 @@ class Show2D(object):
 
         self.i = 0
         vmin, vmax = im.attrs['_image_scaling']
-        if im.ndim == 3:
+        if im.ndim == 3 and not hasattr(im,'voxel'):
             #greyscale image
             self.im = im * (vmax-vmin) + vmin
         else:
@@ -341,7 +341,7 @@ def show_scatterer_slices(scatterer, spacing):
         voxel spacing for the visualization
     """
     vol = scatterer.voxelate(spacing, 0)
-    show2d(vol)
+    Show2D(vol)
 
 
 def check_display():

--- a/holopy/core/io/vis.py
+++ b/holopy/core/io/vis.py
@@ -341,7 +341,7 @@ def show_scatterer_slices(scatterer, spacing):
         voxel spacing for the visualization
     """
     vol = scatterer.voxelate(spacing, 0)
-    Show2D(vol)
+    Show2D(display_image(vol))
 
 
 def check_display():

--- a/holopy/scattering/scatterer/scatterer.py
+++ b/holopy/scattering/scatterer/scatterer.py
@@ -99,7 +99,7 @@ class Scatterer(HoloPyObject):
         index = np.ones_like(domains, dtype=dtype) * background
         for i, n in enumerate(ns):
             index[domains==i+1] = n
-        return xr.DataArray(index, attrs = {'_image_scaling':[0,self.n.max()], 'voxel':1})
+        return index
 
     @property
     def guess(self):

--- a/holopy/scattering/scatterer/scatterer.py
+++ b/holopy/scattering/scatterer/scatterer.py
@@ -99,7 +99,7 @@ class Scatterer(HoloPyObject):
         index = np.ones_like(domains, dtype=dtype) * background
         for i, n in enumerate(ns):
             index[domains==i+1] = n
-        return index
+        return xr.DataArray(index, attrs = {'_image_scaling':[0,self.n.max()], 'voxel':1})
 
     @property
     def guess(self):
@@ -186,7 +186,7 @@ class Scatterer(HoloPyObject):
 
         Returns
         -------
-        voxelation : np.ndarray
+        voxelation : np.ndarray # this should be an xarray
             An array with refractive index at every pixel
         """
         return self.index_at(self._voxel_coords(spacing))


### PR DESCRIPTION
show_scatterer_slices wasn't working. update includes:
- changing voxelated scatterer from ndarray to xarray
- removing the rescaling by vmin and vmax for voxelated scatterers. This rescaling causes the visualisation to show incorrectly because the same vmin and vmax are used again in imshow.