### PR TITLE
fix broken output suppression. fixes #340

### DIFF
--- a/holopy/core/utils.py
+++ b/holopy/core/utils.py
@@ -56,9 +56,10 @@ class SuppressOutput():
             self.stdout_behaves_normally = True
 
     def _redirect_stdout(self, destination_fileno):
-        os.dup2(destination_fileno, self.std_out)
         if self.stdout_behaves_normally:
             sys.stdout.close()
+        os.dup2(destination_fileno, self.std_out)
+        if self.stdout_behaves_normally:
             sys.stdout = io.TextIOWrapper(os.fdopen(self.std_out, 'wb'))
 
     def __enter__(self):


### PR DESCRIPTION
Commit 364d1d8539168de4cc642e5551dec9a893a08b87 inadvertently changed the order of assigning and closing files when suppressing output, which resulted in failure. This PR restores the previous ordering.