### PR TITLE
Adjustments to inference interface

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -21,7 +21,15 @@ Improvements
   accessible by a broader group of classes.
 - PerfectLensModel now accepts hologram scaling factor alpha as a parameter
   for inference.
+- It is now possible to pass an inference strategy to the high-level fit() and
+  sample() functions, either by name or as a Strategy object. These functions
+  are now accessible in the root HoloPy namespace as hp.fit() and hp.sample().
 - New user guide on :ref:`scatterers_user`.
+
+Deprecations
+------------
+- The model.fit() and model.sample() methods have been deprecated in favour of
+  the high-level hp.fit() and hp.sample functions()
 
 Bugfixes
 --------

--- a/holopy/__init__.py
+++ b/holopy/__init__.py
@@ -38,4 +38,4 @@ from holopy.propagation import propagate
 from holopy.inference import fit, sample
 
 __version__ = '3.3.3'
-__version_info__ = tuple([ int(num) for num in __version__.split('.')])
+__version_info__ = tuple([int(num) for num in __version__.split('.')])

--- a/holopy/__init__.py
+++ b/holopy/__init__.py
@@ -35,6 +35,7 @@ from holopy import core, scattering, fitting, inference
 from holopy.core import (load, save, load_image, save_image, show,
                          check_display, detector_grid, detector_points)
 from holopy.propagation import propagate
+from holopy.inference import fit, sample
 
 __version__ = '3.3.3'
 __version_info__ = tuple([ int(num) for num in __version__.split('.')])

--- a/holopy/inference/interface.py
+++ b/holopy/inference/interface.py
@@ -29,21 +29,21 @@ available_fit_strategies = ALL_STRATEGIES['fit']
 available_sampling_strategies = ALL_STRATEGIES['sample']
 
 
-def sample(data, model):
+def sample(data, model, strategy=None):
     if isinstance(model, Model):
-        return model.sample(data)
+        return model.sample(data, strategy)
     else:
         msg = "Sampling model {} is not a HoloPy Model object.".format(model)
         raise ValueError(msg)
 
 
-def fit(data, model, parameters=None):
+def fit(data, model, parameters=None, strategy=None):
     if isinstance(model, Scatterer):
         model = make_default_model(model, parameters)
     elif parameters is not None:
         warnings.warn("Ignoring parameters {} in favour of model {}.".format(
                       parameters, model), UserWarning)
-    return model.fit(data)
+    return model.fit(data, strategy)
 
 
 def make_default_model(base_scatterer, fitting_parameters):

--- a/holopy/inference/interface.py
+++ b/holopy/inference/interface.py
@@ -108,4 +108,3 @@ def make_uniform(guesses, key):
         raise ValueError(msg)
     minval = 0 if key in ['n', 'r'] else -np.inf
     return Uniform(minval, np.inf, guess_value, key)
-

--- a/holopy/inference/interface.py
+++ b/holopy/inference/interface.py
@@ -20,6 +20,7 @@ import warnings
 
 import numpy as np
 
+from holopy.core.holopy_object import SerializableMetaclass
 from holopy.scattering import Scatterer
 from holopy.scattering.scatterer import _interpret_parameters
 from holopy.inference.model import Model, AlphaModel
@@ -68,10 +69,8 @@ def validate_strategy(strategy, operation):
     if not hasattr(strategy, operation):
         raise ValueError("Cannot {} with Strategy of type {}.".format(
             operation, type(strategy).__name__))
-    try:
+    if isinstance(strategy, SerializableMetaclass):
         strategy = strategy()
-    except TypeError:
-        pass
     return strategy
 
 

--- a/holopy/inference/result.py
+++ b/holopy/inference/result.py
@@ -260,8 +260,7 @@ class SamplingResult(FitResult):
 
     def _calc_intervals(self):
         P_LOW = 15.865525393145708  # 100*(1-scipy.special.erf(1/np.sqrt(2)))/2
-        map_val = self.samples[np.unravel_index(
-                                    np.argmax(self.lnprobs), self.lnprobs.shape)]
+        map_val = self.samples[np.unravel_index(np.argmax(self.lnprobs.data), self.lnprobs.shape)]
         minus = map_val - self.samples.reduce(
             np.percentile, q=P_LOW, dim=['walker', 'chain'])
         plus = -map_val + self.samples.reduce(

--- a/holopy/inference/result.py
+++ b/holopy/inference/result.py
@@ -261,7 +261,7 @@ class SamplingResult(FitResult):
     def _calc_intervals(self):
         P_LOW = 15.865525393145708  # 100*(1-scipy.special.erf(1/np.sqrt(2)))/2
         map_val = self.samples[np.unravel_index(
-                                    self.lnprobs.argmax(), self.lnprobs.shape)]
+                                    np.argmax(self.lnprobs), self.lnprobs.shape)]
         minus = map_val - self.samples.reduce(
             np.percentile, q=P_LOW, dim=['walker', 'chain'])
         plus = -map_val + self.samples.reduce(

--- a/holopy/inference/tests/test_interface.py
+++ b/holopy/inference/tests/test_interface.py
@@ -52,14 +52,6 @@ class TestUserFacingFunctions(unittest.TestCase):
         self.assertTrue(hasattr(result, 'samples'))
 
     @attr('medium')
-    def test_fit_works_with_model(self):
-        function_result = fit(DATA, SimpleModel())
-        function_result.time = None
-        object_result = SimpleModel().fit(DATA)
-        object_result.time = None
-        self.assertEqual(function_result, object_result)
-
-    @attr('medium')
     def test_fit_works_with_scatterer(self):
         function_result = fit(DATA, SPHERE)
         function_result.time = None

--- a/holopy/inference/tests/test_interface.py
+++ b/holopy/inference/tests/test_interface.py
@@ -34,9 +34,10 @@ from holopy.inference.result import SamplingResult
 from holopy.inference.tests.common import SimpleModel
 
 DATA = data_grid(np.ones((2, 2)), spacing=1, medium_index=1,
-    illum_wavelen=0.5, illum_polarization = [0,1])
+                 illum_wavelen=0.5, illum_polarization=[0, 1])
 SPHERE = Sphere(n=1, center=[2, 2, 2])
 GUESSES = {'n': 1, 'r': 2, 'center.0': 3}
+
 
 class TestUserFacingFunctions(unittest.TestCase):
     @attr('fast')
@@ -218,6 +219,6 @@ class TestHelperFunctions(unittest.TestCase):
         expected = prior.Uniform(-np.inf, np.inf, 3, 'center.0')
         self.assertEqual(generated, expected)
 
+
 if __name__ == '__main__':
     unittest.main()
-

--- a/holopy/inference/tests/test_model.py
+++ b/holopy/inference/tests/test_model.py
@@ -97,61 +97,6 @@ class TestModel(unittest.TestCase):
                 reloaded = take_yaml_round_trip(model)
                 self.assertEqual(reloaded, model)
 
-class TestModelFittingMethods(unittest.TestCase):
-    @attr('fast')
-    def test_default_fit_strategy_is_nmpfit(self):
-        model = Model(Sphere())
-        default_strategy = model.validate_strategy(None, 'fit')
-        self.assertEqual(NmpfitStrategy(), default_strategy)
-
-    @attr('fast')
-    def test_default_sampling_strategy_is_emcee(self):
-        model = Model(Sphere())
-        default_strategy = model.validate_strategy(None, 'sample')
-        self.assertTrue(isinstance(default_strategy, EmceeStrategy))
-
-    @attr('fast')
-    def test_fit_strategy_names(self):
-        model = Model(Sphere())
-        for name, strategy in available_fit_strategies.items():
-            strategy_by_name = model.validate_strategy(name, 'fit')
-            self.assertEqual(strategy(), strategy_by_name)
-
-    @attr('fast')
-    def test_sample_strategy_names(self):
-        model = Model(Sphere())
-        for name, strategy in available_sampling_strategies.items():
-            if strategy is not NotImplemented:
-                strategy_by_name = model.validate_strategy(name, 'sample')
-                self.assertEqual(strategy(), strategy_by_name)
-
-    @attr('fast')
-    def test_parallel_tempering_not_implemented(self):
-        model = Model(Sphere())
-        self.assertRaises(ValueError, model.validate_strategy,
-                          'parallel tempering', 'sample')
-
-    @attr('medium')
-    def test_model_fit_method_identical_to_strategy_method(self):
-        model = SimpleModel()
-        strategy = NmpfitStrategy(seed = 123)
-        data = np.array(.5)
-        strategy_result = strategy.fit(model, data)
-        strategy_result.time = None
-        model_result = model.fit(data, strategy)
-        model_result.time = None
-        self.assertEqual(strategy_result, model_result)
-
-    @attr('medium')
-    def test_model_sample_method_identical_to_strategy_method(self):
-        model = SimpleModel()
-        strategy = EmceeStrategy(nwalkers=6, nsamples=10, seed=123)
-        data = np.array(.5)
-        strategy_result = strategy.sample(model, data)
-        strategy_result.time = None
-        model_result = model.sample(data, strategy)
-        model_result.time = None
-        self.assertEqual(strategy_result, model_result)
 
 class TestAlphaModel(unittest.TestCase):
     @attr('fast')


### PR DESCRIPTION
Prompted by #354 (Fixes #354). The docs imposed an arbitrary restriction that `fit` and `sample` high-level functions could only take strategy names as strings, and not actual `Strategy` objects, whereas the `model.fit` and `model.sample` methods could handle either strategy names or objects. I found this confusing and arbitrary so I taught the high-level functions to use objects as well as names. However, this resulted in there being no difference in functionality between the high-level functions and the model methods. I decided to deprecate the model methods so there's only one way to do things, and it's the way that is most flexible and best documented. Note that these methods were introduced as part of the 3.0 development cycle and aren't described very well in the docs so we should be able to remove them with the rest of the old fitting infrastructure.