### PR TITLE
Bigspheremielens

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -38,6 +38,8 @@ Bugfixes
 - Fortran output no longer occasionaly leaks through the output supression
   context manager used by multiple scattering theories.
 - Restored ability to visualize slices through a scatterer object
+- The :class:`.MieLens` scattering theory now works for both large and
+  small spheres.
 
 Compatibility Notes
 --------------------

--- a/holopy/inference/tests/test_interface.py
+++ b/holopy/inference/tests/test_interface.py
@@ -113,7 +113,7 @@ class TestStrategyHandling(unittest.TestCase):
         result = fit(DATA, SimpleModel())
         self.assertEqual(result.strategy, NmpfitStrategy())
 
-    @attr('medium')
+    @attr('slow')
     def test_default_sampling_strategy_is_emcee(self):
         result = sample(DATA, SimpleModel())
         self.assertTrue(isinstance(result.strategy, EmceeStrategy))

--- a/holopy/scattering/tests/test_mielensfunctions.py
+++ b/holopy/scattering/tests/test_mielensfunctions.py
@@ -332,23 +332,27 @@ class TestMieLensCalculator(unittest.TestCase):
 
 
 class TestMieScatteringMatrix(unittest.TestCase):
+    default_kwargs = {'index_ratio': 1.1, 'size_parameter': 10.0}
+
     @attr("fast")
     def test_raises_error_on_nans(self):
         theta = np.array([np.nan])
         interpolator = mielensfunctions.MieScatteringMatrix(
-            parallel_or_perpendicular='perpendicular')
+            parallel_or_perpendicular='perpendicular', **self.default_kwargs)
         self.assertRaises(RuntimeError, interpolator._eval, theta)
 
     @attr("fast")
     def test_lazy_eval_sets_up_interpolator(self):
         theta = np.linspace(0, 1.5, 10)
         interpolator = mielensfunctions.MieScatteringMatrix(
-            parallel_or_perpendicular='perpendicular', lazy=True)
+            parallel_or_perpendicular='perpendicular', lazy=True,
+            **self.default_kwargs)
         assert (interpolator._interp is None)
         approx = interpolator(theta)
 
         other = mielensfunctions.MieScatteringMatrix(
-            parallel_or_perpendicular='perpendicular', lazy=False)
+            parallel_or_perpendicular='perpendicular', lazy=False,
+            **self.default_kwargs)
         self.assertEqual(type(interpolator._interp), type(other._interp))
         self.assertTrue(interpolator._interp is not None)
 
@@ -356,7 +360,7 @@ class TestMieScatteringMatrix(unittest.TestCase):
     def test_perpendicular_interpolator_accuracy(self):
         theta = np.linspace(0, 1.5, 1000)
         interpolator = mielensfunctions.MieScatteringMatrix(
-            parallel_or_perpendicular='perpendicular')
+            parallel_or_perpendicular='perpendicular', **self.default_kwargs)
 
         exact = interpolator._eval(theta)
         approx = interpolator(theta)
@@ -369,7 +373,7 @@ class TestMieScatteringMatrix(unittest.TestCase):
     def test_parallel_interpolator_accuracy(self):
         theta = np.linspace(0, 1.5, 1000)
         interpolator = mielensfunctions.MieScatteringMatrix(
-            parallel_or_perpendicular='parallel')
+            parallel_or_perpendicular='parallel', **self.default_kwargs)
 
         exact = interpolator._eval(theta)
         approx = interpolator(theta)
@@ -382,11 +386,12 @@ class TestMieScatteringMatrix(unittest.TestCase):
     def test_interpolator_maxl_accuracy(self):
         theta = np.linspace(0, 1.5, 1000)
         interpolator_low_l = mielensfunctions.MieScatteringMatrix(
-            parallel_or_perpendicular='perpendicular')
+            parallel_or_perpendicular='perpendicular', **self.default_kwargs)
 
         higher_l = np.ceil(interpolator_low_l.size_parameter * 8).astype('int')
         interpolator_higher_l = mielensfunctions.MieScatteringMatrix(
-            parallel_or_perpendicular='perpendicular', max_l=higher_l)
+            parallel_or_perpendicular='perpendicular', max_l=higher_l,
+            **self.default_kwargs)
 
         exact = interpolator_low_l._eval(theta)
         approx = interpolator_higher_l._eval(theta)

--- a/holopy/scattering/tests/test_mielensfunctions.py
+++ b/holopy/scattering/tests/test_mielensfunctions.py
@@ -395,6 +395,18 @@ class TestMieScatteringMatrix(unittest.TestCase):
         is_ok = np.allclose(exact / rescale, approx / rescale, **MEDTOLS)
         self.assertTrue(is_ok)
 
+    @attr('medium')
+    def test_works_when_large_size_parameter(self):
+        theta = np.linspace(0, 1.5, 11)
+        interpolator_low_l = mielensfunctions.MieScatteringMatrix(
+            index_ratio=1.1,
+            size_parameter=1000.0,  # roughly 80 um sphere
+            parallel_or_perpendicular='perpendicular',
+            lazy=True)
+
+        out = interpolator_low_l._eval(theta)
+        self.assertFalse(np.any(np.isnan(out)))
+
 
 class TestGaussQuad(unittest.TestCase):
     @attr("fast")

--- a/holopy/scattering/tests/test_mielensfunctions.py
+++ b/holopy/scattering/tests/test_mielensfunctions.py
@@ -342,21 +342,6 @@ class TestMieScatteringMatrix(unittest.TestCase):
         self.assertRaises(RuntimeError, interpolator._eval, theta)
 
     @attr("fast")
-    def test_lazy_eval_sets_up_interpolator(self):
-        theta = np.linspace(0, 1.5, 10)
-        interpolator = mielensfunctions.MieScatteringMatrix(
-            parallel_or_perpendicular='perpendicular', lazy=True,
-            **self.default_kwargs)
-        assert (interpolator._interp is None)
-        approx = interpolator(theta)
-
-        other = mielensfunctions.MieScatteringMatrix(
-            parallel_or_perpendicular='perpendicular', lazy=False,
-            **self.default_kwargs)
-        self.assertEqual(type(interpolator._interp), type(other._interp))
-        self.assertTrue(interpolator._interp is not None)
-
-    @attr("fast")
     def test_perpendicular_interpolator_accuracy(self):
         theta = np.linspace(0, 1.5, 1000)
         interpolator = mielensfunctions.MieScatteringMatrix(
@@ -406,8 +391,7 @@ class TestMieScatteringMatrix(unittest.TestCase):
         interpolator_low_l = mielensfunctions.MieScatteringMatrix(
             index_ratio=1.1,
             size_parameter=1000.0,  # roughly 80 um sphere
-            parallel_or_perpendicular='perpendicular',
-            lazy=True)
+            parallel_or_perpendicular='perpendicular')
 
         out = interpolator_low_l._eval(theta)
         self.assertFalse(np.any(np.isnan(out)))

--- a/holopy/scattering/theory/mielensfunctions.py
+++ b/holopy/scattering/theory/mielensfunctions.py
@@ -313,8 +313,8 @@ class MieScatteringMatrix(object):
             self._true_pts, self._true_values)
 
     def _default_max_l(self):
-        """An empirically good value for ~1e-7 accuracy"""
-        return np.ceil(4 * self.size_parameter).astype('int')
+        """An empirically good value for ~1e-6 accuracy"""
+        return np.ceil(25 + 1.1 * self.size_parameter).astype('int')
 
     def _default_npts(self):
         # Since tau_l(theta), pi_l(theta) ~ d/dx P_l^1, there are O(l)

--- a/holopy/scattering/theory/mielensfunctions.py
+++ b/holopy/scattering/theory/mielensfunctions.py
@@ -354,9 +354,6 @@ def j2(x):
     return 2. / clipped * j1(clipped) - j0(clipped)
 
 
-# FIXME h1n, h2n return nan's for negative z, which they get called with
-# when the index ratio is negative... either fix this or ensure that
-# scatterers do not get created with negative indices.
 def spherical_h1n(n, z, derivative=False):
     """Spherical Hankel function H_n(z) or its derivative"""
     return spherical_jn(n, z, derivative) + 1j * spherical_yn(n, z, derivative)
@@ -401,16 +398,16 @@ class AlBlFunctions(object):
 
     where :math:`\psi_l` and :math:`\\xi_l` are the Riccati-Bessel
     functions of the first and third kinds, respectively. The
-    definitions used here follow those of van der Hulst [1]_, which
+    definitions used here follow those of van de Hulst [1]_, which
     differ from those used in Bohren and Huffman [2]_.
 
     References
     ----------
-        .. [1] H. C. van der Hulst, "Light Scattering by Small Particles",
-               Dover (1981), pg 123.
-        .. [2] C. F. Bohren and Donald R. Huffman, "Absorption and
-               Scattering of Light by Small Particles", Wiley (2004),
-               pg 101.
+    .. [1] H. C. van de Hulst, "Light Scattering by Small Particles",
+           Dover (1981), pg 123.
+    .. [2] C. F. Bohren and Donald R. Huffman, "Absorption and
+           Scattering of Light by Small Particles", Wiley (2004),
+           pg 101.
     """
 
     @staticmethod
@@ -429,7 +426,6 @@ class AlBlFunctions(object):
         Returns
         -------
         a_l, b_l : numpy.ndarray
-
         """
         psi_nx = AlBlFunctions.riccati_psin(
             l, index_ratio * size_parameter)

--- a/holopy/scattering/theory/mielensfunctions.py
+++ b/holopy/scattering/theory/mielensfunctions.py
@@ -272,8 +272,12 @@ class MieLensCalculator(object):
 
 
 class MieScatteringMatrix(object):
-    def __init__(self, parallel_or_perpendicular='perpendicular',
-                 index_ratio=1.1, size_parameter=1.0, max_l=None, npts=None,
+    def __init__(self,
+                 parallel_or_perpendicular='perpendicular',
+                 index_ratio=None,
+                 size_parameter=None,
+                 max_l=None,
+                 npts=None,
                  lazy=False):
         """Calculations of Mie far-field scattering matrices.
 
@@ -289,11 +293,17 @@ class MieScatteringMatrix(object):
             Index contrast of the particle.
         size_parameter : float
             Size of the sphere in units of 1/k = 1/wavevector
-        max_l : int > 0
-        npts : int > 0
-        lazy : bool
+        max_l : int > 0, optional
+            The maximum order of the series to sum to. Defaults to a
+            good value that trades off numerical accuracy (more terms)
+            and lack-of-errors (less terms).
+        npts : int > 0, optional
+            The number of points for interpolation. Defaults to a good
+            value.
+        lazy : bool, optional
             Whether or not to set up the interpolator right away or
-            to wait until it is called.
+            to wait until it is called. Default is False (i.e. set up an
+            interpolator.)
         """
         self.parallel_or_perpendicular = parallel_or_perpendicular
         self.index_ratio = index_ratio


### PR DESCRIPTION
This PR makes mielens more stable at large size parameters, by changing the default maximum number of terms in the Mie scattering solutions to include.

The old problem was that, for large enough spheres, the Mie scattering matrices were evaluating something of the form (0 - 0) / (0 - 0), which gave nans. To fix this, I found the maximum number of terms I could include in the series, as a function of `size_parameter` for a fixed refractive index ratio. Empirically, this grows ever so slightly faster than linearly. Next, I found the minimum number of terms I could include for a ~1e-6 fractional error, as a function of `size_parameter`. This grows linearly, with a sizeable gap for all size parameters between the minimum number of terms and the maximum, i.e. it should be always possible to compute this numerically, up to `size_parameter=1e4` (or a 790 um sphere), which is the largest that I checked. Then I found a simple functional form for the number of terms in the series to include, as a function of the size parameter.

The old code used the first `4 * size_parameter` terms in the series, which caused errors at sphere sizes of about 14 um. The new code uses the first `25 + 1.1 * size_parameter` terms in the series, as determined above. Both of these are different than what Bohren and Huffman suggest, which is (I believe) `size_parameter**(4/3)`. I used a different scaling because (i) my scaling works empirically, and (ii) using their scaling gives results that crash for large enough `size_parameter`.

All these empirical tests are local and obviously not part of holopy; I'm attaching the script and results below so you can take a look if you want. Be aware; it takes a while to run (hours on my machine, since computing Mie scattering matrices for large spheres is very slow).

I also only checked this with an index ratio of 1.2 (polystyrene in water); if we want, I can check this for a higher contrast. (Lower contrasts should be simpler.)
[fix-mielens-nans.tar.gz](https://github.com/manoharan-lab/holopy/files/5139493/fix-mielens-nans.tar.gz)

