### PR TITLE
Fixlenspolarizationrotation

### DIFF
--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -28,7 +28,7 @@ Improvements
 - Scatterer.parameters() now matches the arguments to create the scatterer
   instead of deconstructing composite objects.
 - New prior.renamed() method to create an identical prior with a new name.
-- New way to easily construct scatterers from model parameters with 
+- New way to easily construct scatterers from model parameters with
   ``model.scatterer_from_parameters()``.
 - New ``model.initial_guess`` attribute which can be used to evaluate initial
   guess by psasing into ``model.scatterer_from_parameters()`` or
@@ -67,6 +67,9 @@ Bugfixes
 - Models can now include xarray parameters and still support saving/loading.
 - The :class:`.MieLens` scattering theory now works for both large and
   small spheres.
+- The :class:`Lens` theory works for arbitrary linear polarization of
+  the incoming light. This bug was not present on any releases, only on
+  the development branch.
 
 Compatibility Notes
 --------------------

--- a/holopy/core/math.py
+++ b/holopy/core/math.py
@@ -93,7 +93,7 @@ def rotation_matrix(alpha, beta, gamma, radians = True):
 
 def transform_cartesian_to_spherical(x_y_z):
     x, y, z = x_y_z
-    r = np.linalg.norm(x_y_z, axis=0)
+    r = np.sqrt(x*x + y*y + z*z)
     theta = np.arctan2(np.sqrt(x**2 + y**2), z)
     phi = np.arctan2(y, x) % (2*np.pi)
     return np.array([r, theta, phi])
@@ -111,6 +111,7 @@ def transform_cartesian_to_cylindrical(x_y_z):
     x, y, z = x_y_z
     rho = np.sqrt(x**2 + y**2)
     phi = np.arctan2(y, x) % (2*np.pi)
+    z = (np.full(rho.size, z) if np.size(z) == 1 else z)
     return np.array([rho, phi, z])
 
 
@@ -118,6 +119,7 @@ def transform_cylindrical_to_cartesian(rho_phi_z):
     rho, phi, z = rho_phi_z
     x = rho * np.cos(phi)
     y = rho * np.sin(phi)
+    z = (np.full(x.size, z) if np.size(z) == 1 else z)
     return np.array([x, y, z])
 
 

--- a/holopy/core/tests/test_utils_math.py
+++ b/holopy/core/tests/test_utils_math.py
@@ -429,3 +429,6 @@ class TestChoosePool(unittest.TestCase):
         auto_pool = choose_pool('auto')
         self.assertTrue(isinstance(auto_pool, (pool.BasePool, mp.pool.Pool)))
 
+
+if __name__ == '__main__':
+    unittest.main()

--- a/holopy/inference/emcee.py
+++ b/holopy/inference/emcee.py
@@ -48,9 +48,13 @@ def sample_one_sigma_gaussian(result):
 
 
 class EmceeStrategy(HoloPyObject):
-    def __init__(self, nwalkers=100, nsamples=1000, npixels=None,
+    _default_nsamples = 1000
+
+    def __init__(self, nwalkers=100, nsamples=None, npixels=None,
                  walker_initial_pos=None, parallel='auto', seed=None):
         self.nwalkers = nwalkers
+        if nsamples is None:
+            nsamples = self._default_nsamples
         self.nsamples = nsamples
         self.npixels = npixels
         self.walker_initial_pos = walker_initial_pos

--- a/holopy/inference/tests/test_interface.py
+++ b/holopy/inference/tests/test_interface.py
@@ -115,8 +115,15 @@ class TestStrategyHandling(unittest.TestCase):
 
     @attr('slow')
     def test_default_sampling_strategy_is_emcee(self):
+        # for speed, we monkey-patch emcee.default_nsamples
+        # FIXME this is maybe not the best way to do this.
+        put_back = EmceeStrategy._default_nsamples * 1
+        EmceeStrategy._default_nsamples = 1
         result = sample(DATA, SimpleModel())
         self.assertTrue(isinstance(result.strategy, EmceeStrategy))
+        # and put it back!!
+        EmceeStrategy._default_nsamples = put_back
+        self.assertNotEqual(EmceeStrategy._default_nsamples, 1)
 
     @attr('fast')
     def test_fit_strategy_names(self):

--- a/holopy/scattering/tests/common.py
+++ b/holopy/scattering/tests/common.py
@@ -31,7 +31,7 @@ xschema = update_metadata(detector_grid(shape=128, spacing=pixel_scale),
                           illum_polarization=xpolarization)
 yschema = update_metadata(xschema, illum_polarization=ypolarization)
 
-xschema_lens = update_metadata(detector_grid(shape=64, spacing=pixel_scale),
+xschema_lens = update_metadata(detector_grid(shape=32, spacing=pixel_scale),
                                illum_wavelen=wavelen, medium_index=index,
                                illum_polarization=xpolarization)
 

--- a/holopy/scattering/tests/test_dda.py
+++ b/holopy/scattering/tests/test_dda.py
@@ -127,6 +127,7 @@ def test_DDA_coated():
     dda_holo = calc_holo(schema, cs, index, wavelen, theory=DDA)
     assert_allclose(lmie_holo, dda_holo, rtol = 5e-4)
 
+
 @with_setup(setup=setup_optics, teardown=teardown_optics)
 def test_Ellipsoid_dda():
     e = Ellipsoid(1.5, r = (.5, .1, .1), center = (1, -1, 10))
@@ -139,9 +140,10 @@ def test_Ellipsoid_dda():
         cmdlist = ['-eq_rad', '0.5', '-shape', 'ellipsoid', '0.2', '0.2', '-m',
                '1.1278195488721805', '0.0', '-orient', '0.0', '0.0', '0.0']
         assert_equal(cmd, cmdlist)
-        verify(h, 'ellipsoid_dda')
+        verify(h, 'ellipsoid_dda', rtol=3e-4, atol=3e-4)
     except DependencyMissing:
         raise SkipTest()
+
 
 @attr('slow')
 def test_predefined_scatterers():
@@ -179,4 +181,4 @@ def test_csg_dda():
 
     rotated_pac = pacman.rotated(np.pi/2, 0, 0)
     hr = calc_holo(sch, rotated_pac, 1.33, .66, illum_polarization=(0, 1))
-    verify(h/hr, 'dda_csg_rotated_div')
+    verify(h/hr, 'dda_csg_rotated_div', rtol=1e-3, atol=1e-3)

--- a/holopy/scattering/tests/test_lens.py
+++ b/holopy/scattering/tests/test_lens.py
@@ -4,6 +4,7 @@ import numpy as np
 import xarray as xr
 from numpy.testing import assert_allclose, assert_equal
 from nose.plugins.attrib import attr
+from scipy.special import iv
 
 try:
     import numexpr as ne
@@ -66,10 +67,10 @@ class TestLens(unittest.TestCase):
         wts = LENSMIE._phi_wts
 
         def func(x):
-            return np.cos(np.pi * x)
+            return np.exp(-3 * np.sin(x))
 
         integral = np.sum(func(pts) * wts)
-        expected_val = np.sin(2 * np.pi ** 2) / np.pi  # analytic result
+        expected_val = 2 * np.pi * iv(0, 3)  # analytic result
         assert_allclose(integral, expected_val)
 
     def test_integrate_over_2D_with_quad_points(self):
@@ -83,10 +84,10 @@ class TestLens(unittest.TestCase):
         wts_theta, wts_phi = np.meshgrid(wts_theta, wts_phi)
 
         def func(theta, phi):
-            return np.cos(theta) * np.cos(np.pi * phi)
+            return np.cos(theta) * np.exp(-3 * np.sin(phi))
 
         integral = np.sum(func(pts_theta, pts_phi) * wts_theta * wts_phi)
-        expected_val = np.sin(1.) * np.sin(2 * np.pi ** 2) / np.pi
+        expected_val = np.sin(LENS_ANGLE) * 2 * np.pi * iv(0, 3)
         assert_allclose(integral, expected_val)
 
     def test_quadrature_scattering_matrix_size(self):

--- a/holopy/scattering/tests/test_lens.py
+++ b/holopy/scattering/tests/test_lens.py
@@ -166,6 +166,28 @@ class TestLens(unittest.TestCase):
         assert_allclose(f0y, fy, atol=2e-3)
         assert_allclose(f0z, fz, atol=2e-3)
 
+    def test_raw_fields_similar_mielens_ypolarization(self):
+        detector = SMALL_DETECTOR
+        scatterer = test_common.sphere
+        medium_wavevec = 2 * np.pi / test_common.wavelen
+        medium_index = test_common.index
+        illum_polarization = xr.DataArray([0, 1.0, 0])
+
+        theory_old = MieLens(lens_angle=LENS_ANGLE)
+        pos_old = theory_old._transform_to_desired_coordinates(
+            detector, scatterer.center, wavevec=medium_wavevec)
+
+        theory_new = LENSMIE
+        pos_new = theory_new._transform_to_desired_coordinates(
+            detector, scatterer.center, wavevec=medium_wavevec)
+
+        args = (scatterer, medium_wavevec, medium_index, illum_polarization)
+        f0x, f0y, f0z = theory_old._raw_fields(pos_old, *args)
+        fx, fy, fz = theory_new._raw_fields(pos_new, *args)
+        assert_allclose(f0x, fx, atol=2e-3)
+        assert_allclose(f0y, fy, atol=2e-3)
+        assert_allclose(f0z, fz, atol=2e-3)
+
     def test_lens_plus_mie_fields_same_as_mielens(self):
         detector = test_common.xschema_lens
         scatterer = test_common.sphere

--- a/holopy/scattering/tests/test_lens.py
+++ b/holopy/scattering/tests/test_lens.py
@@ -17,6 +17,8 @@ import holopy.scattering.tests.common as test_common
 LENS_ANGLE = 1.
 QLIM_TOL = {'atol': 1e-2, 'rtol': 1e-2}
 LENSMIE = Lens(lens_angle=LENS_ANGLE, theory=Mie(False, False))
+LENSMIE_NO_NE = Lens(
+    lens_angle=LENS_ANGLE, theory=Mie(False, False), use_numexpr=False)
 
 
 SMALL_DETECTOR = update_metadata(
@@ -156,13 +158,7 @@ class TestLens(unittest.TestCase):
         krho, phi, kz = np.random.randn(3, 101)
 
         prefactor_numexpr = LENSMIE._integrand_prefactor(krho, phi, kz)
-
-        # Monkey-patch lens to use the numpy pathway:
-        lens.NUMEXPR_INSTALLED = False
-        prefactor_numpy = LENSMIE._integrand_prefactor(krho, phi, kz)
-        lens.NUMEXPR_INSTALLED = True
-        # and put it back:
-        assert lens.NUMEXPR_INSTALLED
+        prefactor_numpy = LENSMIE_NO_NE._integrand_prefactor(krho, phi, kz)
 
         self.assertTrue(np.all(prefactor_numpy == prefactor_numexpr))
 
@@ -177,13 +173,8 @@ class TestLens(unittest.TestCase):
 
         prefactor_numexpr = LENSMIE._integrand_prll(
             prefactor, pol_angle, *scat_matrix)
-        # Monkey-patch lens to use the numpy pathway:
-        lens.NUMEXPR_INSTALLED = False
-        prefactor_numpy = LENSMIE._integrand_prll(
+        prefactor_numpy = LENSMIE_NO_NE._integrand_prll(
             prefactor, pol_angle, *scat_matrix)
-        # and put it back:
-        lens.NUMEXPR_INSTALLED = True
-        assert lens.NUMEXPR_INSTALLED
 
         self.assertTrue(np.all(prefactor_numpy == prefactor_numexpr))
 
@@ -198,13 +189,8 @@ class TestLens(unittest.TestCase):
 
         prefactor_numexpr = LENSMIE._integrand_perp(
             prefactor, pol_angle, *scat_matrix)
-        # Monkey-patch lens to use the numpy pathway:
-        lens.NUMEXPR_INSTALLED = False
-        prefactor_numpy = LENSMIE._integrand_perp(
+        prefactor_numpy = LENSMIE_NO_NE._integrand_perp(
             prefactor, pol_angle, *scat_matrix)
-        # and put it back:
-        lens.NUMEXPR_INSTALLED = True
-        assert lens.NUMEXPR_INSTALLED
 
         self.assertTrue(np.all(prefactor_numpy == prefactor_numexpr))
 

--- a/holopy/scattering/tests/test_lens.py
+++ b/holopy/scattering/tests/test_lens.py
@@ -323,7 +323,7 @@ class TestLensVsMielens(unittest.TestCase):
         assert_allclose(f0y, fy, atol=2e-3)
         assert_allclose(f0z, fz, atol=2e-3)
 
-    def test_lens_plus_mie_fields_same_as_mielens(self):
+    def test_calculate_scattered_field_lensmie_same_as_mielens(self):
         detector = test_common.xschema_lens
         scatterer = test_common.sphere
         medium_wavevec = 2 * np.pi / test_common.wavelen

--- a/holopy/scattering/tests/test_lens.py
+++ b/holopy/scattering/tests/test_lens.py
@@ -300,10 +300,10 @@ class TestLensVsMielens(unittest.TestCase):
 
         args = (scatterer, medium_wavevec, medium_index, illum_polarization)
         f0x, f0y, f0z = theory_old._raw_fields(pos_old, *args)
-        fx, fy, fz = theory_new._raw_fields(pos_new, *args)
-        assert_allclose(f0x, fx, atol=2e-3)
-        assert_allclose(f0y, fy, atol=2e-3)
-        assert_allclose(f0z, fz, atol=2e-3)
+        f1x, f1y, f1z = theory_new._raw_fields(pos_new, *args)
+        assert_allclose(f0x, f1x, atol=2e-3)
+        assert_allclose(f0y, f1y, atol=2e-3)
+        assert_allclose(f0z, f1z, atol=2e-3)
 
     def test_raw_fields_similar_mielens_ypolarization(self):
         detector = SMALL_DETECTOR

--- a/holopy/scattering/tests/test_lens.py
+++ b/holopy/scattering/tests/test_lens.py
@@ -216,7 +216,7 @@ class TestLens(unittest.TestCase):
 
     @attr('medium')
     def test_polarization_rotation_produces_small_changes_to_image(self):
-        # we test that, for two sphere, rotating the polarization is
+        # we test that, for two sphere, rotating the polarization
         # does not drastically change the image
         # We place the two spheres along the line phi = 0
 
@@ -242,7 +242,7 @@ class TestLens(unittest.TestCase):
         intensity_xpol = np.linalg.norm(fields_xpol, axis=0)**2
         intensity_ypol = np.linalg.norm(fields_ypol, axis=0)**2
 
-        # We are just trying to cehck that rotating the polarization
+        # We are just trying to check that rotating the polarization
         # does not rotate the image, so we can afford soft tolerances:
         tols = {'atol': 5e-2, 'rtol': 5e-2}
         self.assertTrue(np.allclose(intensity_xpol, intensity_ypol, **tols))

--- a/holopy/scattering/tests/test_lens.py
+++ b/holopy/scattering/tests/test_lens.py
@@ -242,7 +242,9 @@ class TestLens(unittest.TestCase):
         intensity_xpol = np.linalg.norm(fields_xpol, axis=0)**2
         intensity_ypol = np.linalg.norm(fields_ypol, axis=0)**2
 
-        tols = {'atol': 1e-3, 'rtol': 1e-3}
+        # We are just trying to cehck that rotating the polarization
+        # does not rotate the image, so we can afford soft tolerances:
+        tols = {'atol': 5e-2, 'rtol': 5e-2}
         self.assertTrue(np.allclose(intensity_xpol, intensity_ypol, **tols))
 
 

--- a/holopy/scattering/tests/test_mielens.py
+++ b/holopy/scattering/tests/test_mielens.py
@@ -195,7 +195,7 @@ class TestMieLens(unittest.TestCase):
 
         krho = np.linspace(0, 100, 11)
         phi_0 = 0 * krho + np.pi / 180.0  # a small component along y
-        phi_1 = phi_0 -np.pi / 2
+        phi_1 = phi_0 - np.pi / 2
         kz = np.full_like(krho, 20.0)
 
         pol_0 = xr.DataArray([1.0, 0, 0])

--- a/holopy/scattering/theory/dda.py
+++ b/holopy/scattering/theory/dda.py
@@ -82,7 +82,7 @@ class DDA(ScatteringTheory):
 
         # Check that adda is present and able to run
         try:
-            with SuppressOutput():
+            with SuppressOutput(suppress_output=suppress_C_output):
                 subprocess.check_call(['adda', '-V'])
         except (subprocess.CalledProcessError, OSError):
             raise DependencyMissing('adda', "adda is not included with HoloPy "

--- a/holopy/scattering/theory/lens.py
+++ b/holopy/scattering/theory/lens.py
@@ -90,9 +90,6 @@ class Lens(ScatteringTheory):
     def _compute_integrand(self, positions, scatterer, medium_wavevec,
                            medium_index, illum_polarization):
         krho_p, phi_p, kz_p = positions
-        pol_angle = np.arctan2(illum_polarization[1], illum_polarization[0])
-        phi_p += pol_angle.values
-        phi_p %= (2 * np.pi)
 
         theta_shape = (self.quad_npts_theta, 1, 1)
         th = self._theta_pts.reshape(theta_shape)

--- a/holopy/scattering/theory/lens.py
+++ b/holopy/scattering/theory/lens.py
@@ -50,8 +50,8 @@ class Lens(ScatteringTheory):
         """
         quad_theta_pts, quad_theta_wts = gauss_legendre_pts_wts(
              0, self.lens_angle, npts=self.quad_npts_theta)
-        quad_phi_pts, quad_phi_wts = gauss_legendre_pts_wts(
-             0, 2 * np.pi, npts=self.quad_npts_phi)
+        quad_phi_pts, quad_phi_wts = pts_wts_for_phi_integrals(
+            self.quad_npts_phi)
 
         self._theta_pts = quad_theta_pts
         self._costheta_pts = np.cos(self._theta_pts)
@@ -194,4 +194,15 @@ def gauss_legendre_pts_wts(a, b, npts=100):
     pts = pts_raw * (b - a) * 0.5
     wts = wts_raw * (b - a) * 0.5
     pts += 0.5 * (a + b)
+    return pts, wts
+
+
+def pts_wts_for_phi_integrals(npts):
+    """Quadrature points for integration on the periodic interval [0, pi]
+
+    Since this interval is periodic, we use equally-spaced points with
+    equal weights.
+    """
+    pts = np.linspace(0, 2 * np.pi, npts + 1)[:-1].copy()
+    wts = np.full_like(pts, 2 * np.pi / pts.size)
     return pts, wts


### PR DESCRIPTION
Fixes 371.

This fixes two bugs with the implementation of polarization rotation in the `Lens` theory. These issues were only present when the polarization was not along the x (or [1, 0]) direction. With this PR, the agreement between MieLens and Lens(Mie) does not change with polarization, and both theories produce rotationally-invariant results for rotationally-invariant objects (i.e. the parallel component of the field scattered from a sphere, evaluated at a position that is along the polarizazion vector, does not change as the polarization changes; this was always true for MieLens but was not true for Lens(Mie)).

Note that this does not change the calculations at all when the polarization is along the x-direction, so #350 is still open.