### PR TITLE
Update code to work with recent versions of xarray, ensure tests pass

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - pyyaml
   - pillow
   - pandas
-  - xarray=0.21.1
+  - xarray
   - h5netcdf
   - h5py
   - numexpr

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 # development environment for holopy
 #
 # To use:
-#   conda env create -f .\environment.yml
+#   conda env create -f ./environment.yml
 # and then
 #   conda activate holopy-devel
 #
@@ -33,7 +33,9 @@ dependencies:
   - pint
   - ipython
   - seaborn
-  - mkl-service
+  - sphinx_rtd_theme
+  # for amd64 platforms only; won't be found for aarch64
+  # - mkl-service
   # uncomment to install compilers on windows
   #  - m2w64-toolchain
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,59 @@
+# development environment for holopy
+#
+# To use:
+#   conda env create -f .\environment.yml
+# and then
+#   conda activate holopy-devel
+#
+# To update dependencies after changing this environment file:
+#   conda env update --name holopy-devel --file environment.yml --prune
+#
+# can also use mamba instead of conda in the above
+name: holopy-devel
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.8
+  - numpy<1.20
+  - scipy
+  - pyyaml
+  - pillow
+  - pandas
+  - xarray=0.21.1
+  - h5netcdf
+  - h5py
+  - numexpr
+  - sphinx
+  - matplotlib
+  - emcee=2.2.1
+  - schwimmbad
+  - memory_profiler
+  - cma
+  - pint
+  - ipython
+  - seaborn
+  - mkl-service
+  # uncomment to install compilers on windows
+  #  - m2w64-toolchain
+
+  # include jupyterlab for convenience
+  - jupyterlab
+
+  # for running tests
+  - nose
+  - pytest
+
+  # for development
+  - pyright
+  - pylint
+  - flake8
+  - autoflake
+  - epc
+  - isort
+  - yapf
+  - debugpy
+  - pip
+
+  - pip:
+      - importmagic

--- a/holopy/core/io/io.py
+++ b/holopy/core/io/io.py
@@ -498,7 +498,7 @@ def load_average(
             name = ['x','y'][i]
             return np.around(refimg[name].values/spacing[i]).astype('int')
         mean_image = mean_image.isel(x=extent(0), y=extent(1))
-        std_image =  std_image.isel(x=extent(0), y=extent(1))
+        std_image = std_image.isel(x=extent(0), y=extent(1))
         mean_image['x'] = refimg.x
         mean_image['y'] = refimg.y
         std_image['x'] = refimg.x

--- a/holopy/core/metadata.py
+++ b/holopy/core/metadata.py
@@ -255,6 +255,8 @@ def copy_metadata(old, data, do_coords=True):
     `xr.DataArray`
     """
 
+    new = data.copy()
+
     def find_and_rename(oldkey, oldval):
         for newkey, newval in new.coords.items():
             if np.array_equal(oldval.values, newval.values):
@@ -262,8 +264,6 @@ def copy_metadata(old, data, do_coords=True):
             msg = ("Coordinate {} does not appear to have ".format(oldkey) +
                    "a corresponding coordinate in {}".format(new))
             raise ValueError(msg)
-
-    new = data.copy()
 
     old_is_xarray = isinstance(old, xr.DataArray)
     if old_is_xarray:
@@ -274,7 +274,9 @@ def copy_metadata(old, data, do_coords=True):
         new.name = old.name
 
         if hasattr(old, 'flat') and hasattr(new, 'flat'):
-            new['flat'] = old['flat']
+            # use reindex_like() to preserve order of MultiIndex and derived
+            # coordinates, or arrays may be misaligned
+            new = new.reindex_like(old)
         if do_coords:
             for key, val in old.coords.items():
                 if key not in new.coords:

--- a/holopy/core/process/centerfinder.py
+++ b/holopy/core/process/centerfinder.py
@@ -87,7 +87,7 @@ def center_find(image, centers=1, threshold=.5, blursize=3.):
     """
     image=copy(image)
     if blursize>0:
-        image.values = gaussian_filter(image.values,blursize)
+        image.values = gaussian_filter(image.values, blursize)
     col_deriv, row_deriv = image_gradient(image)
     while col_deriv.ndim > 2:
         col_deriv = col_deriv[:,:,0]

--- a/holopy/core/process/centerfinder.py
+++ b/holopy/core/process/centerfinder.py
@@ -38,7 +38,7 @@ video microscopy, Optics Express 17, 13071-13079 (2009).
 
 import numpy as np
 from .img_proc import normalize
-from scipy.ndimage import sobel, filters
+from scipy.ndimage import sobel, gaussian_filter
 from copy import copy
 
 def center_find(image, centers=1, threshold=.5, blursize=3.):
@@ -87,7 +87,7 @@ def center_find(image, centers=1, threshold=.5, blursize=3.):
     """
     image=copy(image)
     if blursize>0:
-        image.values = filters.gaussian_filter(image.values,blursize)
+        image.values = gaussian_filter(image.values,blursize)
     col_deriv, row_deriv = image_gradient(image)
     while col_deriv.ndim > 2:
         col_deriv = col_deriv[:,:,0]

--- a/holopy/core/tests/test_io.py
+++ b/holopy/core/tests/test_io.py
@@ -239,7 +239,7 @@ class test_custom_yaml_output(unittest.TestCase):
 class TestMemoryUsage(unittest.TestCase):
     @unittest.skipIf(not importlib.util.find_spec('memory_profiler'),
                      'memory_profiler is required for this test')
-    #@unittest.expectedFailure
+    # @unittest.expectedFailure
     # unittest.expectedFailure doesn't work in nose
     # see https://github.com/nose-devs/nose/issues/33
     # TODO: return to unittest.expectedFailure after switch to pytest

--- a/holopy/core/tests/test_io.py
+++ b/holopy/core/tests/test_io.py
@@ -28,6 +28,7 @@ import yaml
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 from nose.plugins.attrib import attr
+from nose.tools import raises
 from PIL import Image as pilimage
 from PIL.TiffImagePlugin import ImageFileDirectory_v2 as ifd2
 
@@ -237,8 +238,13 @@ class test_custom_yaml_output(unittest.TestCase):
 
 class TestMemoryUsage(unittest.TestCase):
     @unittest.skipIf(not importlib.util.find_spec('memory_profiler'),
-                     'memory_profiler is reqruired for this test')
-    @unittest.expectedFailure
+                     'memory_profiler is required for this test')
+    #@unittest.expectedFailure
+    # unittest.expectedFailure doesn't work in nose
+    # see https://github.com/nose-devs/nose/issues/33
+    # TODO: return to unittest.expectedFailure after switch to pytest
+    # Workaround for now:
+    @raises(AssertionError)
     def test_load_average_doesnt_use_excess_mem(self):
         # TODO: Why does load_average use so much memory?
         # See manoharan-lab/holopy#267

--- a/holopy/core/tests/test_io.py
+++ b/holopy/core/tests/test_io.py
@@ -336,9 +336,11 @@ class TestAccumulator(unittest.TestCase):
         paths = get_example_data_path(['2colourbg0.jpg', '2colourbg1.jpg',
                                        '2colourbg2.jpg', '2colourbg3.jpg'])
         image = load_average(paths, spacing=1, channel=[0,1])
-        gold_noise = [0.06864433355667054, 0.04913377621162473]
-        noise = [image.noise_sd.loc[colour].item()
-                 for colour in ['green', 'red']]
+        # previous values from Solomon (not sure how to reproduce):
+        #   gold_noise = [0.06864433355667054, 0.04913377621162473]
+        # new values, from mean over pixels of CV at each pixel
+        gold_noise = [0.06909666, 0.04879883]
+        noise = image.noise_sd.sel(illumination=['green', 'red']).values
         self.assertTrue(np.allclose(gold_noise, noise))
 
 

--- a/holopy/core/tests/test_io.py
+++ b/holopy/core/tests/test_io.py
@@ -303,33 +303,39 @@ class TestAccumulator(unittest.TestCase):
         accumulator = Accumulator()
         data = np.arange(10)
         for point in data: accumulator.push(point)
-        self.assertTrue(accumulator._std() == np.std(data))
+        self.assertTrue(accumulator.std() == np.std(data))
 
     @attr("fast")
     def test_std_no_data(self):
         accumulator = Accumulator()
-        self.assertTrue(accumulator._std() is None)
-
-    @attr("fast")
-    def test_cv(self):
-        accumulator = Accumulator()
-        data = np.arange(10)
-        for point in data: accumulator.push(point)
-        self.assertTrue(accumulator.cv() == np.std(data) / np.mean(data))
-
-    @attr("fast")
-    def test_cv_no_data(self):
-        accumulator = Accumulator()
-        self.assertTrue(accumulator.cv() is None)
+        self.assertTrue(accumulator.std() is None)
 
     @attr("medium")
     def test_calculate_hologram_noise_sd(self):
-        accumulator = Accumulator()
         refimg = _load_raw_example_data()
         paths = get_example_data_path(['bg01.jpg', 'bg02.jpg', 'bg03.jpg'])
         bg = load_average(paths, refimg)
         # This value is from the legacy version of load_average
         self.assertTrue(np.allclose(bg.noise_sd, 0.00709834))
+
+    @attr("medium")
+    def test_welford(self):
+        # tests Welford's algorithm against standard 2-pass algorithm
+        paths = get_example_data_path(['bg01.jpg', 'bg02.jpg', 'bg03.jpg'])
+        # duplicate several times to do a better check for numerical stability
+        paths = paths*10
+        # Welford method
+        mean_image = load_average(paths, spacing=1)
+        welford_mean = mean_image.mean().values
+        welford_std = mean_image.std().values
+        # two-pass method
+        images = np.stack([load_image(imfile, spacing=1) for imfile in paths],
+                          axis=-1)
+        twopass_mean_image = np.mean(images, axis=-1)
+        twopass_mean = twopass_mean_image.mean()
+        twopass_std = twopass_mean_image.std()
+        self.assertTrue(np.allclose([welford_mean, welford_std],
+                                    [twopass_mean, twopass_std]))
 
     @attr('fast')
     def test_2_colour_noise_sd(self):


### PR DESCRIPTION
As of `xarray` v2022.06.0, arrays with a `MultiIndex` no longer have associated "virtual" coordinates but instead have real coordinates (https://docs.xarray.dev/en/stable/whats-new.html#v2022-06-0rc0-9-june-2022) . Some of our code had assumed that the x, y, z dimensions associated with a flattened detector schema would remain virtual, but that code broke when they became non-virtual, and the x, y, z dimensions started getting duplicated in our metadata update operations. This PR fixes this problem, allowing `holopy` to be used with more recent versions of `xarray`.  

Fixes 
#409
#411
#415

Other changes:

- added environment.yml file to make it easier to setup a conda environment for developing holopy
- fixed some deprecation warnings associated with changes in `scipy.ndimage`
- created workaround for incompatibility of `nose` with `unittest.expectedFailure`.

`test_2_colour_noise_sd (test_io.TestAccumulator)` is failing, but other tests are passing. This test was failing before any changes were made.