### PR TITLE
Re-gold two-color noise test

### DIFF
--- a/holopy/core/io/io.py
+++ b/holopy/core/io/io.py
@@ -498,7 +498,7 @@ def load_average(
             name = ['x','y'][i]
             return np.around(refimg[name].values/spacing[i]).astype('int')
         mean_image = mean_image.isel(x=extent(0), y=extent(1))
-        std_image =  std_image.isel(x=extent(0), y=extent(1))
+        std_image = std_image.isel(x=extent(0), y=extent(1))
         mean_image['x'] = refimg.x
         mean_image['y'] = refimg.y
         std_image['x'] = refimg.x

--- a/holopy/core/tests/test_io.py
+++ b/holopy/core/tests/test_io.py
@@ -330,9 +330,11 @@ class TestAccumulator(unittest.TestCase):
         paths = get_example_data_path(['2colourbg0.jpg', '2colourbg1.jpg',
                                        '2colourbg2.jpg', '2colourbg3.jpg'])
         image = load_average(paths, spacing=1, channel=[0,1])
-        gold_noise = [0.06864433355667054, 0.04913377621162473]
-        noise = [image.noise_sd.loc[colour].item()
-                 for colour in ['green', 'red']]
+        # previous values from Solomon (not sure how to reproduce):
+        #   gold_noise = [0.06864433355667054, 0.04913377621162473]
+        # new values, from mean over pixels of CV at each pixel
+        gold_noise = [0.06909666, 0.04879883]
+        noise = image.noise_sd.sel(illumination=['green', 'red']).values
         self.assertTrue(np.allclose(gold_noise, noise))
 
 


### PR DESCRIPTION
[`test_2_colour_noise_sd`](https://github.com/manoharan-lab/holopy/blob/3bed86e3b493245deb9d8d74904c991bf13caaf5/holopy/core/tests/test_io.py#L329-L336) is failing for me. I have tried several approaches (using numpy on the raw images in addition to using the code currently in `holopy.core.io.io.py`) to reproduce the gold values of the noise_sd that are reported in the test, but I can't reproduce these values. This might be related to #430, in that a different method was used to generate the gold values than the one we currently use. In any case, it seems that changing the gold values is the simplest approach here.

This PR also cleans up some of the code in `load_average()` and the `Accumulator` class. In particular, I removed the method `accumulator.cv()` since it does pixel-wise averaging for multiple channels, and the `Accumulator` class doesn't require a labeled array and so is ignorant of coordinates and channels (as it should be). The calculation of the coefficient of variation is now in `load_average()`. I removed the tests associated with the `accumulator.cv()` method and added a new test to verify the numerical accuracy of the Welford algorithm implementation in `accumulator.push()` (see #276 for why we needed to implement this approach). The new code now takes advantage of `xarray` coordinate labels.