### PR TITLE
Fix output suppression from multisphere and DDA codes

### DIFF
--- a/holopy/core/utils.py
+++ b/holopy/core/utils.py
@@ -41,41 +41,6 @@ except ModuleNotFoundError:
 from holopy.core.errors import DependencyMissing
 from holopy.core.holopy_object import HoloPyObject
 
-
-# FIXME this is difficult to test, since it works on the file level
-# perhaps make this capture the output rather than writing it to devnull?
-class SuppressOutput():
-    def __init__(self, suppress_output=True):
-        self.suppress_output = suppress_output
-        try:
-            self.std_out = sys.stdout.fileno()
-        except io.UnsupportedOperation:
-            self.stdout_behaves_normally = False  # ie running on travis
-            self.std_out = 1
-        else:
-            self.stdout_behaves_normally = True
-
-    def _redirect_stdout(self, destination_fileno):
-        if self.stdout_behaves_normally:
-            sys.stdout.close()
-        os.dup2(destination_fileno, self.std_out)
-        if self.stdout_behaves_normally:
-            sys.stdout = io.TextIOWrapper(os.fdopen(self.std_out, 'wb'))
-
-    def __enter__(self):
-        if self.suppress_output:
-            # store default (current) stdout
-            self.default_stdout = os.dup(self.std_out)
-            self.devnull = os.open(os.devnull, os.O_WRONLY)
-            self._redirect_stdout(self.devnull)
-
-    def __exit__(self, *args):
-        if self.suppress_output:
-            self._redirect_stdout(self.default_stdout)
-            os.close(self.devnull)
-            os.close(self.default_stdout)
-
-
 def ensure_array(x):
     '''
     if x is None, returns None. Otherwise, gives x in a form so that each of:

--- a/holopy/scattering/tests/test_lowlevel.py
+++ b/holopy/scattering/tests/test_lowlevel.py
@@ -345,8 +345,8 @@ def test_asm():
     # propagation as positive, we have it negative), so we multiply the
     # z coordinate by -1 to correct for that.
     _, lmax, amn0, converged = scsmfo_min.amncalc(
-        1, centers[:,0],  centers[:,1], -1.0 * centers[:,2],  m.real,
-        m.imag, size_p, niter, eps, qeps1, qeps2,  meth, (0,0),
+        1, centers[:, 0], centers[:, 1], -1.0 * centers[:, 2], m.real,
+        m.imag, size_p, niter, eps, qeps1, qeps2, meth, (0, 0),
         suppress_output)
     limit = lmax**2 + 2*lmax
     amn = amn0[:, 0:limit, :]

--- a/holopy/scattering/theory/dda.py
+++ b/holopy/scattering/theory/dda.py
@@ -22,8 +22,8 @@ ADDA (https://github.com/adda-team/adda) to do DDA calculations.
 """
 
 # TODO: Adda currently fails if you call it with things specified in meters
-# (values are too small), so we should probably nondimensionalize before talking
-# to adda.
+# (values are too small), so we should probably nondimensionalize before
+# talking to adda.
 
 import subprocess
 import tempfile

--- a/holopy/scattering/theory/dda.py
+++ b/holopy/scattering/theory/dda.py
@@ -21,21 +21,20 @@ ADDA (https://github.com/adda-team/adda) to do DDA calculations.
 .. moduleauthor:: Thomas G. Dimiduk <tdimiduk@physics.harvard.edu>
 """
 
-#TODO: Adda currently fails if you call it with things specified in meters
-#(values are too small), so we should probably nondimensionalize before talking
-#to adda.
+# TODO: Adda currently fails if you call it with things specified in meters
+# (values are too small), so we should probably nondimensionalize before talking
+# to adda.
 
 import subprocess
 import tempfile
 import glob
 import os
 import shutil
-import time
 import warnings
 
 import numpy as np
 
-from holopy.core.utils import ensure_array, SuppressOutput
+from holopy.core.utils import ensure_array
 from holopy.scattering.scatterer import (
     Ellipsoid, Capsule, Cylinder, Bisphere, Sphere, Scatterer, Spheroid)
 from holopy.core.errors import DependencyMissing
@@ -82,8 +81,11 @@ class DDA(ScatteringTheory):
 
         # Check that adda is present and able to run
         try:
-            with SuppressOutput(suppress_output=suppress_C_output):
-                subprocess.check_call(['adda', '-V'])
+            # capture_output tells run() to capture stdout and stderr and
+            # return them or put them in a CalledProcessError exception. Here
+            # we're just using this option to suppress the output.
+            subprocess.run(['adda', '-V'], capture_output=suppress_C_output,
+                           check=True)
         except (subprocess.CalledProcessError, OSError):
             raise DependencyMissing('adda', "adda is not included with HoloPy "
                 "and must be installed separately. You should be able to run "
@@ -125,12 +127,18 @@ class DDA(ScatteringTheory):
         predefined = isinstance(scatterer, tuple(_get_predefined_shape.keys()))
         layered=isinstance(scatterer, Sphere) and not np.isscalar(scatterer.r)
         if not predefined or self.use_indicators or layered:
-            scat_args = self._adda_discretized(scatterer, medium_wavelen, medium_index, temp_dir)
+            scat_args = self._adda_discretized(scatterer, medium_wavelen,
+                                               medium_index, temp_dir)
         else:
-            scat_args = self._adda_predefined(scatterer, medium_wavelen, medium_index, temp_dir)
+            scat_args = self._adda_predefined(scatterer, medium_wavelen,
+                                              medium_index, temp_dir)
         cmd.extend(scat_args)
-        with SuppressOutput(suppress_output=self.suppress_C_output):
-            subprocess.check_call(cmd, cwd=temp_dir)
+        adda_out = subprocess.run(cmd, cwd=temp_dir, check=True,
+                                  capture_output=self.suppress_C_output)
+
+        # adda_out is a subprocess.CompletedProcess object that contains the
+        # output of ADDA; could be used for diagnostics
+        return adda_out
 
     # TODO: figure out why our discretization gives a different result
     # and fix so that we can use that and eliminate this.

--- a/holopy/scattering/theory/mie_f/mieangfuncs.f90
+++ b/holopy/scattering/theory/mie_f/mieangfuncs.f90
@@ -120,7 +120,7 @@
            else
                call asm_mie_far(nstop, asbs, theta, asm_scat)
            endif
-           
+
            ! calculate scattered fields in spherical coordinates
            call calc_scat_field(kr, phi, asm_scat, einc, escat_sph)
 
@@ -149,7 +149,7 @@
       subroutine mie_internal_fields(n_pts, calc_points, m, csds, nstop, &
            einc, eint_x, eint_y, eint_z)
         ! Calculate internal fields inside a sphere in the Lorenz-Mie solution,
-        ! at a list of selected points.  
+        ! at a list of selected points.
         !
         ! Function calls from Python may need to transpose calc_points.
         !
@@ -187,7 +187,7 @@
              eint_y, eint_z
         integer :: i
         complex (kind = 8), dimension(3) :: eint_sph, eint_cart1, eint_cart2
-        
+
         ! Loop over field points
         do i = 1, n_pts, 1
            mkr = m * calc_points(1, i)
@@ -210,7 +210,7 @@
            eint_y(i) = eint_cart1(2) + eint_cart2(2)
            eint_z(i) = eint_cart1(3) + eint_cart2(3)
         end do
-      
+
         return
         end
 
@@ -323,7 +323,7 @@
         ! initialize
         data ci/(0.d0, 1.d0)/
         esph_out = (/ 0., 0., 0. /)
-        
+
         ! special function calls
         call pisandtaus(nstop, theta, pi_l, tau_l)
         call csphjy(nstop, mkr, nmx_csphjy, jl, djl, yl, dyl)
@@ -332,9 +332,9 @@
         do n = 1, nstop, 1
            pref_up = 2. * n + 1.
            pref_dn = n * (n + 1.)
-           derj = jl(n) / mkr + djl(n) 
+           derj = jl(n) / mkr + djl(n)
            ! radial
-           esph_out(1) = esph_out(1) + ci**(n-1) * pref_up * csds(2, n) * & 
+           esph_out(1) = esph_out(1) + ci**(n-1) * pref_up * csds(2, n) * &
                 st * pi_l(n) * jl(n) / mkr
            ! theta
            esph_out(2) = esph_out(2) + ci**n * pref_up / pref_dn * &
@@ -446,9 +446,9 @@
         return
         end
 
-     
+
       subroutine radial_field_mie(nstop, as, kr, theta, erad_nd)
-        ! Calculate non-dimensional radial component of the scattered 
+        ! Calculate non-dimensional radial component of the scattered
         ! Lorenz-Mie electric field. Physical E_scat,radial requires
         ! an overall prefactor of E_\parallel,inc (incident field parallel
         ! to scattering plane).
@@ -508,7 +508,7 @@
 
         ! main loop
         do n = 1, nstop, 1
-           prefactor = 2 * n + 1 
+           prefactor = 2 * n + 1
            hl = jn(n) + ci * yn(n) ! spherical hankel
            erad_nd = erad_nd + as(1, n) * prefactor * ci**(n + 1) * &
                 st * pi_n(n) * hl / kr
@@ -552,7 +552,7 @@
         st = dsin(theta)
         cp = dcos(phi)
         sp = dsin(phi)
-        
+
         acart(1) = st * cp * a_r
         acart(2) = st * sp * a_r
         acart(3) = ct * a_r
@@ -640,9 +640,9 @@
         ! Calculate logarithmic derivatives D_n(z) of the Riccati-Bessel
         ! function \psi_n(z) by downward recursion as in BHMIE.
         ! Calculate from n = 0 to n = nstop, using D_nmx = start_val as the
-        ! starting point for downward recursion.        
+        ! starting point for downward recursion.
         ! Inputs:
-        !    z: argument 
+        !    z: argument
         !    nmx: value of n from which down recursion starts
         !    nstop: maximum returned order
         !    start_val: value from which recursion begins
@@ -664,7 +664,7 @@
         Dn_out = Dn(0:nstop)
         return
         end
-      
+
 
         subroutine lentz_dn1(z, n, eps1, eps2, Dn)
           ! Calculate logarithmic derivative D_n(z) of the Riccati-Bessel
@@ -694,7 +694,7 @@
                nth_convergent, nth_product, ai, aiplus1, aiplus2, &
                xi1, xi2
           integer :: ctr
-          
+
           a1 = a_i(1)
           a2 = a_i(2)
 
@@ -733,14 +733,14 @@
 
               nth_product = numerator / denominator
               nth_convergent = nth_convergent * nth_product
-              ctr = ctr + 1    
+              ctr = ctr + 1
 
            end do
 
        Dn = nth_convergent - n / z
 
         contains
-          complex (kind = 8) function a_i(i) 
+          complex (kind = 8) function a_i(i)
             ! Calculate a_n according to Lentz eqn. 9
             ! or Wiscombe eqn. 25b. Note that Lentz's v = our n + 0.5
             ! and Lentz's n is i here.

--- a/holopy/scattering/theory/multisphere.py
+++ b/holopy/scattering/theory/multisphere.py
@@ -190,10 +190,10 @@ class Multisphere(ScatteringTheory):
         # have laser propagation as positive, we have it negative),
         # so we multiply the z coordinate by -1 to correct for that.
         _, lmax, amn0, converged = scsmfo_min.amncalc(
-            1, centers[:,0],  centers[:,1],
-            -1.0 * centers[:,2],  m.real, m.imag,
+            1, centers[:, 0], centers[:, 1],
+            -1.0 * centers[:, 2], m.real, m.imag,
             scatterer.r * medium_wavevec, self.niter, self.eps,
-            self.qeps1, self.qeps2, self.meth, (0,0), suppress_flag)
+            self.qeps1, self.qeps2, self.meth, (0, 0), suppress_flag)
 
         # converged == 1 if the SCSMFO iterative solver converged
         # f2py converts F77 LOGICAL to int

--- a/holopy/scattering/theory/multisphere.py
+++ b/holopy/scattering/theory/multisphere.py
@@ -33,7 +33,6 @@ from numpy import arctan2, sin, cos
 from warnings import warn
 from scipy.integrate import dblquad
 
-from holopy.core.utils import SuppressOutput
 from holopy.core.errors import DependencyMissing
 from holopy.scattering.scatterer import Spheres,Sphere
 from holopy.scattering.errors import (
@@ -183,15 +182,18 @@ class Multisphere(ScatteringTheory):
         if (centers > 1e4).any():
             raise InvalidScatterer(scatterer, "Particle separation "
                                         "too large, calculation would take forever")
-        with SuppressOutput(suppress_output=self.suppress_fortran_output):
-            # The fortran code uses oppositely directed z axis (they
-            # have laser propagation as positive, we have it negative),
-            # so we multiply the z coordinate by -1 to correct for that.
-            _, lmax, amn0, converged = scsmfo_min.amncalc(
-                1, centers[:,0],  centers[:,1],
-                -1.0 * centers[:,2],  m.real, m.imag,
-                scatterer.r * medium_wavevec, self.niter, self.eps,
-                self.qeps1, self.qeps2,  self.meth, (0,0))
+        if self.suppress_fortran_output:
+            suppress_flag = 1
+        else:
+            suppress_flag = 0
+        # The fortran code uses oppositely directed z axis (they
+        # have laser propagation as positive, we have it negative),
+        # so we multiply the z coordinate by -1 to correct for that.
+        _, lmax, amn0, converged = scsmfo_min.amncalc(
+            1, centers[:,0],  centers[:,1],
+            -1.0 * centers[:,2],  m.real, m.imag,
+            scatterer.r * medium_wavevec, self.niter, self.eps,
+            self.qeps1, self.qeps2, self.meth, (0,0), suppress_flag)
 
         # converged == 1 if the SCSMFO iterative solver converged
         # f2py converts F77 LOGICAL to int


### PR DESCRIPTION
The `SuppressOutput` context manager was wreaking havoc with `pytest`. The problem, as noted in #403, is that the context manager closes `stdout`, which `pytest` (and `ipython`) expect to remain open. We originally did this because the multisphere code keeps outputting to `stdout` even when python attempts to redirect `stdout` to `/dev/null`. This is a general problem when wrapping fortran codes in python. This PR fixes this issue by removing the context manager and modifying the `amncalc` subroutine in `scsmfo_min` to not print anything unless it is told otherwise. The other place that the `SuppressOutput` context manager was used was in the code that interfaces with DDA. Since we call ADDA in a subprocess, the output can be suppressed by using the `capture_output` kwarg of `subprocess.run()`.

Fixes #403. With these changes, `pytest` now runs, though there is some additional work to do to fully integrate it.
