### PR TITLE
changes for python 3.9, numpy 1.20

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,8 +14,8 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.8
-  - numpy<1.20
+  - python=3.9
+  - numpy<1.21
   - scipy
   - pyyaml
   - pillow

--- a/holopy/core/metadata.py
+++ b/holopy/core/metadata.py
@@ -43,7 +43,7 @@ illumination = 'illumination'
 
 
 def detector_grid(shape, spacing, name=None, extra_dims=None):
-    """
+    r"""
     Create a rectangular grid of pixels to represent a detector on which
     scattering calculations are to be performed.
 

--- a/holopy/core/tests/test_prior.py
+++ b/holopy/core/tests/test_prior.py
@@ -588,6 +588,10 @@ class TestPriorMath(unittest.TestCase):
         transformed = TransformedPrior(np.maximum, [prior_1, prior_2])
         self.assertEqual(np.maximum(prior_1, prior_2), transformed)
 
+    # this won't work in numpy 1.21 or later because numpy will now check to
+    # see if "name" is a valid kwarg of the ufunc before passing it on to
+    # __array_ufunc__.  See
+    # https://numpy.org/devdocs/release/1.21.0-notes.html#array-ufunc-argument-validation
     @pytest.mark.fast
     def test_numpy_ufunc_passes_through_name(self):
         prior_1 = Uniform(2, 8, name='unused')

--- a/holopy/inference/result.py
+++ b/holopy/inference/result.py
@@ -288,9 +288,9 @@ class UncertainValue(HoloPyObject):
         from IPython.display import Math
         confidence = ""
         if self.n_sigma != 1:
-            confidence = " (\mathrm{{{}\ sigma}})".format(self.n_sigma)
+            confidence = " (\\mathrm{{{}\\ sigma}})".format(self.n_sigma)
         display_precision = int(
-            round(np.log10(self.guess/(min(self.plus, self.minus))) + .6))
+            np.round(np.log10(self.guess/(min(self.plus, self.minus))) + .6))
         guess_fmt = "{{:.{}g}}".format(max(display_precision, 2))
         guess = guess_fmt.format(self.guess)
         return "${guess}^{{+{s.plus:.2g}}}_{{-{s.minus:.2g}}}{conf}$".format(

--- a/holopy/scattering/theory/mie_f/miescatlib.py
+++ b/holopy/scattering/theory/mie_f/miescatlib.py
@@ -127,7 +127,7 @@ def nstop(x):
     Criterion taken from [Wiscombe1980]_.
     '''
     # 7/7/08: generalize to apply same criterion when x is complex
-    return int(np.round_(np.absolute(x+4.05*x**(1./3.)+2)))
+    return int(np.round(np.absolute(x+4.05*x**(1./3.)+2)))
 
 def asymmetry_parameter(al, bl):
     '''


### PR DESCRIPTION
This PR contains some small fixes to allow HoloPy to work with python 3.9 and numpy 1.20.3.  Later versions of python will not work with numpy 1.20, and later versions of numpy [have changed argument parsing](https://numpy.org/doc/stable/release/1.21.0-notes.html#array-ufunc-argument-validation) for ufuncs, so that some of the current code (see [this test](https://github.com/manoharan-lab/holopy/blob/7fd410e3cbc5083cfdb6bc24e1393d370748b1ef/holopy/core/tests/test_prior.py#L592)) for applying ufuncs to `Prior` objects will break. To avoid breaking current code when v3.6.0 of HoloPy is released, we should target python 3.9 and numpy 1.20.3 and no later versions.