### PR TITLE
fixed undefined symbols identified by flake8

### DIFF
--- a/holopy/core/io/io.py
+++ b/holopy/core/io/io.py
@@ -256,7 +256,7 @@ def load_image(inf, spacing=None, medium_index=None, illum_wavelen=None,
             channel = range(arr.shape[2])
         channel = ensure_array(channel)
         if channel.max() >= arr.shape[2]:
-            raise LoadError(filename,
+            raise LoadError(inf,
                 "The image doesn't have a channel number {0}".format(channel.max()))
         else:
             arr = arr[:, :, channel].squeeze()
@@ -415,7 +415,7 @@ def _save_im(filename, im, depth=8):
             depth = depth-1
             typestr = 'int' + str(depth)
         else:
-            raise Error("Unknown image depth")
+            raise ValueError("Unknown image depth")
 
         if im.max() <= 1:
             im = im * ((2**depth)-1) + .499999

--- a/holopy/core/io/vis.py
+++ b/holopy/core/io/vis.py
@@ -46,14 +46,14 @@ class VisualizationNotImplemented(Exception):
             self.o.__class__.__name__)
 
 
-def show(o, scaling='auto', vert_axis='x', horiz_axis='y',
-                    depth_axis='z', colour_axis='illumination'):
+def show(obj, scaling='auto', vert_axis='x', horiz_axis='y',
+         depth_axis='z', colour_axis='illumination'):
     """
     Visualize a hologram or reconstruction
 
     Parameters
     ----------
-    o : xarray.DataArray or ndarray
+    obj : xarray.DataArray or ndarray
         Object to visualize
     scaling : (float, float), optional
         (min, max) value to display in image, default is full range of o.
@@ -72,11 +72,11 @@ def show(o, scaling='auto', vert_axis='x', horiz_axis='y',
     to import all of matplotlib or mayavi just to load holopy)
     """
 
-    if isinstance(o, (xr.DataArray, np.ndarray, list, tuple)):
-        Show2D(display_image(o, scaling, vert_axis, horiz_axis, depth_axis,
-                                                                colour_axis))
+    if isinstance(obj, (xr.DataArray, np.ndarray, list, tuple)):
+        Show2D(display_image(obj, scaling, vert_axis, horiz_axis, depth_axis,
+                             colour_axis))
     else:
-        raise VisualizationNotImplemented(o)
+        raise VisualizationNotImplemented(obj)
 
 
 def save_plot(filenames, data, scaling='auto', vert_axis='x', horiz_axis='y',
@@ -87,10 +87,7 @@ def save_plot(filenames, data, scaling='auto', vert_axis='x', horiz_axis='y',
     Parameters
     ----------
     filenames : list / str
-        Name(s) of the file(s). If there is only one image contained (e.g.
-        hologram), the name will be used as a file name. If o contains more
-        plottable images (e.g. reconstruction volume), it should be a list of
-        filenames with the same length as objects.
+        Name(s) of the file(s).
     data : xarray.DataArray or ndarray
         Object to save.
     scaling : (float, float), optional
@@ -118,7 +115,7 @@ def save_plot(filenames, data, scaling='auto', vert_axis='x', horiz_axis='y',
         else:
             s.save(filenames)
     else:
-        raise VisualizationNotImplemented(o)
+        raise VisualizationNotImplemented(data)
 
 
 class Show2D(object):
@@ -309,26 +306,26 @@ def show_sphere_cluster(s, color):
     we hope to re-implement this functionality eventually.
     """
     raise NotImplementedError("3D renders of Spheres not currently supported")
-    # Delayed imports to avoid hard dependencies on plotting packages and to
-    # avoid the cost of importing them in noninteractive code
-    from matplotlib import cm
+    # # Delayed imports to avoid hard dependencies on plotting packages and to
+    # # avoid the cost of importing them in noninteractive code
+    # from matplotlib import cm
 
-    mlab = import_mayavi()
+    # mlab = import_mayavi()
 
-    # scale factor is 2 because mayavi interprets 4th
-    # argument as a diameter, we keep track of radii
-    # view is chosen to be looking from the incoming laser's point of view
-    if color == 'rainbow':
-        for i in arange(0,len(s.x)):
-            numberofcolors = max(10,len(s.x))
-            mlab.points3d(s.x[i], s.y[i], s.z[i], s.r[i],
-                scale_factor=2.0, resolution=32,
-                color=cm.gist_rainbow(float(i)/numberofcolors)[0:3])
-            mlab.view(-90,0,s.z[:].mean())
-    else:
-        mlab.points3d(s.x, s.y, s.z, s.r, scale_factor=2.0,
-            resolution=32, color=color)
-        mlab.view(-90,0,s.z[:].mean())
+    # # scale factor is 2 because mayavi interprets 4th
+    # # argument as a diameter, we keep track of radii
+    # # view is chosen to be looking from the incoming laser's point of view
+    # if color == 'rainbow':
+    #     for i in arange(0,len(s.x)):
+    #         numberofcolors = max(10,len(s.x))
+    #         mlab.points3d(s.x[i], s.y[i], s.z[i], s.r[i],
+    #             scale_factor=2.0, resolution=32,
+    #             color=cm.gist_rainbow(float(i)/numberofcolors)[0:3])
+    #         mlab.view(-90,0,s.z[:].mean())
+    # else:
+    #     mlab.points3d(s.x, s.y, s.z, s.r, scale_factor=2.0,
+    #         resolution=32, color=color)
+    #     mlab.view(-90,0,s.z[:].mean())
 
 
 def show_scatterer_slices(scatterer, spacing):

--- a/holopy/core/prior.py
+++ b/holopy/core/prior.py
@@ -38,14 +38,14 @@ def _reciprocal(val):
 
 
 class Prior(HoloPyObject):
-    """Base class for Bayesian priors in holopy.
-    
-       Prior subclasses should define at least the following methods:
-       
-           - guess
-           - sample
-           - prob
-           - lnprob
+    """
+    Base class for Bayesian priors in holopy.
+
+    Prior subclasses should define at least the following methods:
+    - guess
+    - sample
+    - prob
+    - lnprob
     """
 
     def __init__(self):
@@ -341,7 +341,6 @@ class TransformedPrior(Prior):
         else:
             return np.array([self.transformation(*sample_set)
                              for sample_set in zip(*raw_samples)])
-        return samples
 
     @property
     def guess(self):

--- a/holopy/inference/tests/test_minimizer.py
+++ b/holopy/inference/tests/test_minimizer.py
@@ -56,10 +56,9 @@ def test_minimizer():
 
     # now test limiting minimizer iterations
     minimizer = Nmpfit(maxiter=1)
-    try:
-        result, minimization_details = minimizer.minimize(parameters, cost_func)
-    except MinimizerConvergenceFailed as cf: # the fit shouldn't converge
-        result, minimization_details = cf.result, cf.details
+    result, minimization_details = minimizer.minimize(parameters, cost_func)
+    # the fit shouldn't converge (error code 5 from nmpfit)
+    assert minimization_details.status==5
     assert_equal(minimization_details.niter, 2) # there's always an offset of 1
 
 

--- a/holopy/inference/third_party/nmpfit.py
+++ b/holopy/inference/third_party/nmpfit.py
@@ -16,20 +16,18 @@
 # You should have received a copy of the GNU General Public License
 # along with HoloPy.  If not, see <http://www.gnu.org/licenses/>.
 """
-nmpfit.py
-
 Levenberg-Marquardt minimizer obtained from
 
 http://stsdas.stsci.edu/pyraf/stscidocs/pytools_pkg/pytools_api/pytools.nmpfit-module.html
 
 The source code above was modified by Jerome Fung (jerome.fung@post.harvard.edu) to
-be independent of the rest of the stsci_python package, since holopy does
-
+be independent of the rest of the stsci_python package, since holopy does not
 use Numeric.
 '''
 
 '''
-Python/Numeric version of this module was called mpfit. This version was modified to use numpy.
+Python/Numeric version of this module was called mpfit. This version was
+modified to use numpy.
 
 The license for stsci_python is included below:
 
@@ -51,7 +49,8 @@ THIS SOFTWARE IS PROVIDED BY AURA ``AS IS'' AND ANY EXPRESS OR IMPLIED
 WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
 EVENT SHALL AURA BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
 INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
@@ -464,10 +463,10 @@ Perform Levenberg-Marquardt least-squares minimization, based on MINPACK-1.
         August, 2002.  Mark Rivers
 """
 
-#The following lines are irrelevant to holopy and were commented out
-#from the stsci_python version by J. Fung.
-#import numerixenv
-#numerixenv.check()
+# The following lines are irrelevant to holopy and were commented out
+# from the stsci_python version by J. Fung.
+# import numerixenv
+# numerixenv.check()
 
 import numpy
 import types
@@ -1043,7 +1042,7 @@ e.g. mpfit.status, mpfit.errmsg, mpfit.params, npfit.niter, mpfit.covar.
             else: qanylim = 0
         else:
             ## Fill in local variables with dummy values
-            qulim = numpy.zeros(nfree, dtype=n.int8)
+            qulim = numpy.zeros(nfree, dtype=numpy.int8)
             ulim  = x * 0.
             qllim = qulim
             llim  = x * 0.

--- a/holopy/scattering/scatterer/composite.py
+++ b/holopy/scattering/scatterer/composite.py
@@ -25,14 +25,13 @@ scatterers (e.g. two trimers).
 
 
 from copy import copy
-from numbers import Number
-import warnings
 
 import numpy as np
 
 from holopy.scattering.scatterer.scatterer import Scatterer
 from holopy.core.math import rotate_points
-from holopy.core.utils import ensure_array, dict_without
+from holopy.core.utils import ensure_array
+from holopy.scattering.errors import InvalidScatterer
 
 
 class Scatterers(Scatterer):

--- a/holopy/scattering/tests/test_pickle.py
+++ b/holopy/scattering/tests/test_pickle.py
@@ -17,13 +17,21 @@
 # along with HoloPy.  If not, see <http://www.gnu.org/licenses/>.
 
 import pytest
+try:
+   import cPickle as pickle
+except:
+   import pickle
 
-from holopy.core.tests.common import assert_pickle_roundtrip
+from holopy.core.tests.common import (
+    assert_pickle_roundtrip,
+    assert_method_equal
+)
 from holopy.scattering.theory import Mie
 
+# currently not tested
 def assert_method_roundtrip(o):
-    #assert_method_equal(o, pickle.loads(pickle.dumps(o)), 'pickled method')
-    assert_method_equal(o, cPickle.loads(cPickle.dumps(o)), 'pickled method')
+    assert_method_equal(o, pickle.loads(pickle.dumps(o)), 'pickled method')
+    #assert_method_equal(o, cPickle.loads(cPickle.dumps(o)), 'pickled method')
 
 @pytest.mark.fast
 def test_pickle_mie_object():

--- a/holopy/scattering/theory/tmatrix.py
+++ b/holopy/scattering/theory/tmatrix.py
@@ -24,6 +24,7 @@ Compute holograms using Mishchenko's T-matrix method for axisymmetric scatterers
 import copy
 
 import numpy as np
+import warnings
 
 from holopy.scattering.scatterer import Sphere, Spheroid, Cylinder
 from holopy.scattering.errors import TheoryNotCompatibleError, TmatrixFailure


### PR DESCRIPTION
This PR fixes a lot of undefined variables, classes, and function names found by running
```
flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
```
These would have led to runtime errors but the undefined symbols were in places that aren't typically reached in normal execution.