### PR TITLE
Numpy-related fixes and deprecations

### DIFF
--- a/docs/source/tutorial/fit_tutorial.rst
+++ b/docs/source/tutorial/fit_tutorial.rst
@@ -215,16 +215,12 @@ intermediate values:
     shell = np.sqrt(prior.Uniform(1, 2, name='base_area')) / 2 + 0.1
     shell.name = 'shell'
 
-It's always a good idea to assign your priors names when working with
-:class:`.TransformedPrior` objects to keep track of their relationships.
-Parameter names will be generated if none are provided but they might not be
-very informative. To help with naming, you can even assign names to
-:class:`.TransformedPrior` objects when using numpy ufuncs!
-
-..  testcode::
-
-    diameter = np.sqrt(sphere_area / np.pi, name='diameter')
-
+In the second line we assigned the name ``shell`` to the
+:class:`.TransformedPrior` object that was automatically created in the first
+line. Without this line, our new :class:`.TransformedPrior` would have retained
+the name ``base_area``, which is no longer a proper description of the prior.
+It's always a good idea to explicitly assign names to your priors when working
+with objects to keep track of their relationships.
 
 .. _infer_tutorial:
 

--- a/holopy/core/io/vis.py
+++ b/holopy/core/io/vis.py
@@ -292,7 +292,7 @@ def display_image(im, scaling='auto', vert_axis='x', horiz_axis='y',
             im = clean_concat(channels, colour_axis)
         elif len(im[colour_axis]) == 2:
             dummy = xr.full_like(im[{colour_axis:0}], fill_value=im.min())
-            dummy = dummy.expand_dims({colour_axis: [np.NaN]})
+            dummy = dummy.expand_dims({colour_axis: [np.nan]})
             im.attrs['_dummy_channel'] = -1
             im = clean_concat([im, dummy], colour_axis)
     dim_order = [depth_axis, vert_axis, horiz_axis, colour_axis][:im.ndim]

--- a/holopy/core/prior.py
+++ b/holopy/core/prior.py
@@ -110,7 +110,8 @@ class Prior(HoloPyObject):
     def __array_ufunc__(self, ufunc, method, *args, name=None, **kwargs):
         if method == "__call__" and len(kwargs) == 0:
             if name is not None:
-                msg = ("Setting the name of a transformed prior in a ufunc is deprecated. "
+                msg = ("Setting the name of a transformed prior in a ufunc "
+                       "is deprecated. "
                        "Instead set the name explicitly after creation.")
                 warn(msg, DeprecationWarning, stacklevel=2)
                 return TransformedPrior(ufunc, args, name)

--- a/holopy/core/prior.py
+++ b/holopy/core/prior.py
@@ -23,6 +23,7 @@ import numpy as np
 from numpy import random
 from numbers import Number, Real
 from scipy import stats
+from warnings import warn
 
 from holopy.core.metadata import get_extents, get_spacing
 from holopy.core.utils import ensure_listlike
@@ -108,7 +109,13 @@ class Prior(HoloPyObject):
 
     def __array_ufunc__(self, ufunc, method, *args, name=None, **kwargs):
         if method == "__call__" and len(kwargs) == 0:
-            return TransformedPrior(ufunc, args, name)
+            if name is not None:
+                msg = ("Setting the name of a transformed prior in a ufunc is deprecated. "
+                       "Instead set the name explicitly after creation.")
+                warn(msg, DeprecationWarning, stacklevel=2)
+                return TransformedPrior(ufunc, args, name)
+            else:
+                return TransformedPrior(ufunc, args)
         else:
             raise TypeError('Could not apply numpy ufunc to Prior object. '
                             'Use TransformedPrior.')

--- a/holopy/core/tests/test_prior.py
+++ b/holopy/core/tests/test_prior.py
@@ -596,7 +596,9 @@ class TestPriorMath(unittest.TestCase):
     def test_numpy_ufunc_passes_through_name(self):
         prior_1 = Uniform(2, 8, name='unused')
         new_name = 'name_from_numpy'
-        transformed = np.sqrt(prior_1, name=new_name)
+        # ensure DeprecationWarning appears:
+        with pytest.deprecated_call():
+            transformed = np.sqrt(prior_1, name=new_name)
         self.assertEqual(transformed.name, new_name)
 
     @pytest.mark.fast

--- a/holopy/inference/nmpfit.py
+++ b/holopy/inference/nmpfit.py
@@ -171,7 +171,7 @@ class NmpfitStrategy(HoloPyObject):
         nmp_pars = []
         for par in parameters:
             d = {'parname': par.name, 'value': par.scale(par.guess),
-                 'limited': [False, False], 'limits': [np.NaN, np.NaN]}
+                 'limited': [False, False], 'limits': [np.nan, np.nan]}
             if hasattr(par, "lower_bound") and par.lower_bound > -np.inf:
                 d['limited'][0] = True
                 d['limits'][0] = par.scale(par.lower_bound)

--- a/holopy/scattering/tests/test_mielens.py
+++ b/holopy/scattering/tests/test_mielens.py
@@ -89,7 +89,7 @@ class TestMieLens(unittest.TestCase):
             this_sphere = Sphere(n=sphere_index, r=radius, center=center)
             holo = calc_holo(xschema, this_sphere, index, wavelen,
                              xpolarization, theory=theory)
-            is_ok.append(holo.data.ptp() > 0)
+            is_ok.append(np.ptp(holo.data) > 0)
         self.assertTrue(all(is_ok))
 
     @pytest.mark.fast
@@ -159,7 +159,7 @@ class TestMieLens(unittest.TestCase):
 
         # but their max and min values should be close:
         ptp_close_ish = np.isclose(
-            holo_mielens.values.ptp(), holo_mieonly.values.ptp(), atol=0.1)
+            np.ptp(holo_mielens.values), np.ptp(holo_mieonly.values), atol=0.1)
         # and their median should be close:
         median_close_ish = np.isclose(
             np.median(holo_mielens), np.median(holo_mieonly), atol=0.1)

--- a/holopy/scattering/tests/test_mielensfunctions.py
+++ b/holopy/scattering/tests/test_mielensfunctions.py
@@ -5,6 +5,7 @@ import itertools
 import numpy as np
 from numpy.polynomial.chebyshev import Chebyshev
 from scipy.special import jn_zeros
+from scipy.integrate import trapezoid
 
 import pytest
 
@@ -802,7 +803,7 @@ class CheckEnergyIsConserved(object):
         i2 = self.mielenscalculator._eval_mielens_i_n(krho, n=2)
 
         integrand = (np.abs(i0)**2 + np.abs(i2)**2) * krho
-        return 0.5 * np.trapz(integrand, krho)
+        return 0.5 * trapezoid(integrand, krho)
 
     def check_if_energy_is_conserved(self):
         ratio = self.get_ratio_of_powerin_to_powerout()

--- a/holopy/scattering/tests/test_mielensfunctions.py
+++ b/holopy/scattering/tests/test_mielensfunctions.py
@@ -449,7 +449,7 @@ class TestMieScatteringMatrix(unittest.TestCase):
         msm_highl = mielensfunctions.MieScatteringMatrix(
             parallel_or_perpendicular='perpendicular', max_l=1000,
             **self.default_kwargs)
-        should_be_warned = 'invalid value encountered in cdouble_scalars'
+        should_be_warned = 'invalid value encountered'
         with self.assertWarnsRegex(Warning, should_be_warned):
             warnings.simplefilter('always')
             s_theta = msm_highl._eval(theta)

--- a/holopy/scattering/theory/mielensfunctions.py
+++ b/holopy/scattering/theory/mielensfunctions.py
@@ -223,7 +223,7 @@ class MieLensCalculator(object):
             The value of the integrand evaluated at the krho points.
         """
         if self.interpolate_integrals == 'check':
-            n_interp_pnts = (self.interpolator_degree * krho.ptp() /
+            n_interp_pnts = (self.interpolator_degree * np.ptp(krho) /
                              self.interpolator_window_size)
             n_krho_pts = krho.size
             interpolate_integrals = n_interp_pnts < 1.1 * n_krho_pts


### PR DESCRIPTION
Per #435, we are targeting numpy 1.20.3 for HoloPy 3.6. This PR fixes some code that uses numpy constructs that will not work in later numpy versions (>1.20.3) . These fixes will allow us to more easily transition to numpy version 2 in later versions of HoloPy.

This PR also deprecates passing the `name` argument to a numpy ufunc to create a TransformedPrior, a feature that was added in HoloPy 3.5. Unfortunately, versions of numpy >1.20.3 [have added argument validation](https://numpy.org/doc/stable/release/1.21.0-notes.html#array-ufunc-argument-validation) for ufuncs, so that trying to create a `TranformedPrior` object by doing, for example, `transformed = np.sqrt(prior_1, name=new_name)` will fail on these later numpy versions with a `TypeError`.  A `DeprecationWarning` is now issued, and the feature will be removed in HoloPy 3.7.  Documentation has been updated to no longer discuss this feature, and a test has been added to check for the `DeprecationWarning`.