### PR TITLE
Fixing bug in transfer function (>= vs. >)

### DIFF
--- a/holopy/propagation/convolution_propagation.py
+++ b/holopy/propagation/convolution_propagation.py
@@ -175,10 +175,10 @@ def trans_func(schema, d, med_wavelen, cfsp=0, gradient_filter=0):
 
     # Set the transfer function to zero where the sqrt is imaginary
     # (this is equivalent to making sure that the largest spatial
-    # frequency is 1/wavelength).  (root>=0) returns a boolean matrix
+    # frequency is 1/wavelength).  (root>0) returns a boolean matrix
     # that is equal to 1 where the condition is true and 0 where it is
     # false.  Multiplying by this boolean matrix masks the array.
-    g = g * (root >= 0)
+    g = g * (root > 0)
 
     if cfsp > 0:
         g = g ** cfsp


### PR DESCRIPTION
Changed g = g*(root >= 0) to g = g*(root > 0). The point of this line is to mask out the spatial frequencies greater than 1/wavelength, which don't make sense physically. These are the frequencies where root is negative. But a few lines earlier there was this line: root *= (root >= 0) which already turned all the negative values of root into zero. So multiplying g by (root > 0) instead of (root >= 0) is required to properly mask out the points where root = 0 (the points where root was originally negative).

I can work on also writing a test function to check if there are any other issues with reconstruction, but for now I just changed that one line.